### PR TITLE
clear all or individual connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7510,6 +7510,16 @@
         "semver": "5.5.0"
       }
     },
+    "hadron-react-buttons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hadron-react-buttons/-/hadron-react-buttons-2.0.0.tgz",
+      "integrity": "sha512-shkayTcDPQPhLdZnkz0+rr5EBcjHc1HIqQDKKCqfbVT65wKU+PhB2fkIcFcvTmppeFEMYIO1+GCUtn8E1JT4zA==",
+      "requires": {
+        "prop-types": "15.6.1",
+        "react": "16.3.2",
+        "react-dom": "16.3.2"
+      }
+    },
     "hadron-react-components": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hadron-react-components/-/hadron-react-components-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   },
   "dependencies": {
     "ampersand-rest-collection": "^5.0.0",
+    "hadron-react-buttons": "^2.0.0",
     "hadron-react-components": "^2.0.0",
     "keytar": "mongodb-js/node-keytar#fdef09013f576b7a257ad768939e827882bccef5",
     "lodash.filter": "^4.6.0",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -27,6 +27,7 @@ const ConnectActions = Reflux.createActions([
   'onSSHTunnelChanged',
   'onSaveConnection',
   'onDeleteConnection',
+  'onDeleteConnections',
   'onConnectionSelected',
   'onConnect',
   'onDisconnect',

--- a/src/components/sidebar/favorites.jsx
+++ b/src/components/sidebar/favorites.jsx
@@ -40,8 +40,10 @@ class Favorites extends React.Component {
           key={i}
           title={title}
           onClick={this.onFavoriteClicked.bind(this, favorite)}>
-          <div className="connect-sidebar-list-item-last-used">{this.formatLastUsed(favorite)}</div>
-          <div className="connect-sidebar-list-item-name">{favorite.name}</div>
+          <div>
+            <div className="connect-sidebar-list-item-last-used">{this.formatLastUsed(favorite)}</div>
+            <div className="connect-sidebar-list-item-name">{favorite.name}</div>
+          </div>
         </li>
       );
     });

--- a/src/components/sidebar/recents.jsx
+++ b/src/components/sidebar/recents.jsx
@@ -12,6 +12,14 @@ class Recents extends React.Component {
     Actions.onConnectionSelected(recent);
   }
 
+  onClearConnectionClicked(recent) {
+    Actions.onDeleteConnection(recent);
+  }
+
+  onClearConnectionsClicked() {
+    Actions.onDeleteConnections();
+  }
+
   getClassName(recent) {
     let className = 'connect-sidebar-list-item';
     if (this.props.currentConnection === recent) {
@@ -40,19 +48,36 @@ class Recents extends React.Component {
           key={i}
           title={title}
           onClick={this.onRecentClicked.bind(this, recent)}>
-          <div className="connect-sidebar-list-item-last-used">{this.formatLastUsed(recent)}</div>
-          <div className="connect-sidebar-list-item-name">{title}</div>
+          <div>
+            <div className="connect-sidebar-list-item-last-used">{this.formatLastUsed(recent)}</div>
+            <div className="connect-sidebar-list-item-name">{title}</div>
+          </div>
+          <i onClick={this.onClearConnectionClicked.bind(this, recent)} className="fa fa-trash-o fa-lg"></i>
         </li>
       );
     });
   }
 
   render() {
+    const recents = this.props.connections.filter((connection) => {
+      return !connection.is_favorite;
+    });
+
+    const clearClassName = 'connect-sidebar-header-recent-clear';
+    const clearAllDiv = recents.length > 0
+      ? <div onClick={this.onClearConnectionsClicked} className={clearClassName}>Clear All</div>
+      : '';
+
     return (
       <div className="connect-sidebar-connections-recents">
         <div className="connect-sidebar-header">
-          <i className="fa fa-fw fa-history" />
-          <span>Recents</span>
+          <div className="connect-sidebar-header-recent">
+            <div>
+              <i className="fa fa-fw fa-history" />
+              <span>Recents</span>
+            </div>
+            {clearAllDiv}
+          </div>
         </div>
         <ul className="connect-sidebar-list">
           {this.renderRecents()}

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -302,6 +302,17 @@ const ConnectStore = Reflux.createStore({
   },
 
   /**
+   * Delete all recents
+   *
+   * @param {Connection} connection - The connection to delete.
+   */
+  onDeleteConnections() {
+    this._pruneAll(() => {
+      this.trigger(this.state);
+    });
+  },
+
+  /**
    * Delete a connection.
    *
    * @param {Connection} connection - The connection to delete.
@@ -510,6 +521,20 @@ const ConnectStore = Reflux.createStore({
     SSH_TUNNEL_FIELDS.forEach((field) => {
       this.state.currentConnection[field] = undefined;
     });
+  },
+
+  _pruneAll(done) {
+    const recents = this.state.connections.filter((connection) => {
+      return !connection.is_favorite;
+    });
+    for (let i = 0; i < recents.length; i++) {
+      recents[i].destroy({
+        success: () => {
+          this.state.connections.remove(recents[i]._id);
+        }
+      });
+    }
+    done();
   },
 
   _pruneRecents(done) {

--- a/styles/sidebar.less
+++ b/styles/sidebar.less
@@ -1,3 +1,5 @@
+@import (reference) "./compass/palette.less";
+
 .connect-sidebar {
   display: flex;
   flex-direction: column;
@@ -35,10 +37,31 @@
       color: #fff;
     }
 
-    span {
-      font-size: 12px;
-      font-weight: bold;
-      text-transform: uppercase;
+    &-recent {
+      display: flex;
+      justify-content: space-between;
+
+      &:hover {
+        div {
+          visibility: visible;
+        }
+      }
+
+      span {
+        font-size: 12px;
+        font-weight: bold;
+        text-transform: uppercase;
+      }
+
+      &-clear {
+        text-transform: uppercase;
+        visibility: hidden;
+        color: @linkOnDark;
+        margin-right: 10px;
+        font-weight: 600;
+        font-size: 12px;
+        cursor: pointer;
+      }
     }
   }
 
@@ -48,8 +71,23 @@
     padding-left: 0px;
 
     &-item {
-      padding: 5px 0px 6px 28px;
+      padding: 5px 28px 6px 28px;
       cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+
+      &:hover {
+        i {
+          visibility: visible;
+        }
+      }
+
+      i {
+        visibility: hidden;
+        padding-top: 10px;
+        flex-grow: 0;
+        color: #fff;
+      }
 
       &-is-active {
         background-color: #6D7984;

--- a/test/enzyme/recents.test.js
+++ b/test/enzyme/recents.test.js
@@ -9,7 +9,8 @@ chai.use(chaiEnzyme());
 
 describe('<Recents />', () => {
   describe('#render', () => {
-    const recents = [{ hostname: 'dev', port: 27000, is_recent: false }];
+    const recents = [{ hostname: 'dev', port: 27000, is_recent: true, is_favorite: false}];
+
     const component = mount(
       <Recents currentConnection={{}} connections={recents} />
     );
@@ -24,6 +25,14 @@ describe('<Recents />', () => {
 
     it('renders the recents icon', () => {
       expect(component.find('i.fa-history')).to.be.present();
+    });
+
+    it('renders clear all connections text', () => {
+      expect(component.find('.connect-sidebar-header-recent-clear')).to.have.text('Clear All');
+    });
+
+    it('renders clear individual connection icon', () => {
+      expect(component.find('.fa.fa-trash-o.fa-lg')).to.be.present();
     });
 
     it('renders the recent name', () => {


### PR DESCRIPTION
This PR allows users to clear all recent connections together, or get rid of them one by one. If no recent connections are found, `CLEAR ALL` text won't appear so people don't get confused o/

The interaction looks something like this:
![vqnrdnzo3z](https://user-images.githubusercontent.com/8107784/42159465-209cc7c4-7df4-11e8-8fc8-9dfa84e2f031.gif)
