### PR TITLE
fix overflow on list-item-name and colour on clear

### DIFF
--- a/styles/sidebar.less
+++ b/styles/sidebar.less
@@ -56,7 +56,8 @@
       &-clear {
         text-transform: uppercase;
         visibility: hidden;
-        color: @linkOnDark;
+        text-decoration: underline;
+        color: #fff;
         margin-right: 10px;
         font-weight: 600;
         font-size: 12px;
@@ -101,6 +102,7 @@
       }
 
       &-name {
+        max-width: 150px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
Clear button is now white and underlined.
![screen shot 2018-07-19 at 11 32 38 am](https://user-images.githubusercontent.com/8107784/42935659-7b89c3d6-8b4a-11e8-92c6-74e0444b5ee9.png)


Text overflow is back to being to be ellipsised (?) on the list-item-name for connection names. It needed a max-width with the new flex-box set up. 
![screen shot 2018-07-19 at 11 54 09 am](https://user-images.githubusercontent.com/8107784/42935663-7f5455c6-8b4a-11e8-9d4a-ebf3eaee0c0c.png)
