### PR TITLE
COMPASS-3911 manage favorites after connecting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,11 +264,6 @@
         }
       }
     },
-    "@icons/material": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
-    },
     "@mongodb-js/compass-auth-kerberos": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@mongodb-js/compass-auth-kerberos/-/compass-auth-kerberos-3.0.1.tgz",
@@ -10301,7 +10296,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -11343,7 +11339,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -12416,6 +12413,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -12505,11 +12503,6 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
-    },
-    "material-colors": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "math-random": {
       "version": "1.0.1",
@@ -16743,7 +16736,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-component": {
       "version": "0.0.3",
@@ -18037,6 +18031,7 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
@@ -18319,19 +18314,6 @@
         "warning": "^3.0.0"
       }
     },
-    "react-color": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.17.3.tgz",
-      "integrity": "sha512-1dtO8LqAVotPIChlmo6kLtFS1FP89ll8/OiA8EcFRDR+ntcK+0ukJgByuIQHRtzvigf26dV5HklnxDIvhON9VQ==",
-      "requires": {
-        "@icons/material": "^0.2.4",
-        "lodash": "^4.17.11",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      }
-    },
     "react-dnd": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-7.7.0.tgz",
@@ -18491,14 +18473,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2",
         "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "reactcss": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "requires": {
-        "lodash": "^4.0.1"
       }
     },
     "read-package-json": {
@@ -21416,11 +21390,6 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
-    },
-    "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "tmp": {
       "version": "0.0.28",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12079,6 +12079,11 @@
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.min": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/lodash.min/-/lodash.min-3.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "lodash.foreach": "^4.5.0",
     "lodash.isempty": "^4.4.0",
     "lodash.map": "^4.6.0",
+    "lodash.merge": "^4.6.2",
     "lodash.sortby": "^4.7.0"
   }
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,8 +1,10 @@
 const Reflux = require('reflux');
 
 const Actions = Reflux.createActions({
+  deleteFavorite: { sync: true },
   hideFavoriteMessage: { sync: true },
   hideFavoriteModal: { sync: true },
+  saveFavorite: { sync: true },
   showFavoriteMessage: { sync: true },
   showFavoriteModal: { sync: true },
   validateConnectionString: { sync: true },

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,10 +1,8 @@
 const Reflux = require('reflux');
 
 const Actions = Reflux.createActions({
-  deleteFavorite: { sync: true },
   hideFavoriteMessage: { sync: true },
   hideFavoriteModal: { sync: true },
-  saveFavorite: { sync: true },
   showFavoriteMessage: { sync: true },
   showFavoriteModal: { sync: true },
   validateConnectionString: { sync: true },

--- a/src/components/form/connection-form.jsx
+++ b/src/components/form/connection-form.jsx
@@ -20,6 +20,7 @@ class ConnectionForm extends React.Component {
 
   static propTypes = {
     currentConnection: PropTypes.object.isRequired,
+    isValid: PropTypes.bool.isRequired,
     isHostChanged: PropTypes.bool,
     isPortChanged: PropTypes.bool
   };
@@ -121,7 +122,9 @@ class ConnectionForm extends React.Component {
                 {this.renderPort()}
                 <SRVInput isSrvRecord={this.props.currentConnection.isSrvRecord} />
               </FormGroup>
-              <Authentication {...this.props} />
+              <Authentication
+                currentConnection={this.props.currentConnection}
+                isValid={this.props.isValid} />
             </div>
           </div>
         </div>

--- a/src/components/form/connection-form.spec.js
+++ b/src/components/form/connection-form.spec.js
@@ -11,61 +11,139 @@ class TestComponent extends React.Component {
 }
 
 describe('ConnectionForm [Component]', () => {
-  context('tab is Hostname', () => {
-    const appRegistry = new AppRegistry();
-    const connection = {
-      authStrategy: 'MONGODB',
-      isSrvRecord: false,
-      readPreference: 'primaryPreferred',
-      attributes: { hostanme: 'localhost' }
-    };
-    const AUTH_ROLE = {
-      name: 'MONGODB',
-      component: TestComponent,
-      selectOption: { 'MONGODB': 'Username / Password' }
-    };
-    let component;
+  context('when active tab is Hostname', () => {
+    context('when connection string was not changed', () => {
+      const appRegistry = new AppRegistry();
+      const connection = {
+        authStrategy: 'MONGODB',
+        isSrvRecord: false,
+        readPreference: 'primaryPreferred',
+        attributes: { hostanme: 'localhost' }
+      };
+      const isHostChanged = false;
+      const isPortChanged = false;
+      const AUTH_ROLE = {
+        name: 'MONGODB',
+        component: TestComponent,
+        selectOption: { 'MONGODB': 'Username / Password' }
+      };
+      let component;
 
-    before(() => {
-      global.hadronApp = hadronApp;
-      global.hadronApp.appRegistry = appRegistry;
-      global.hadronApp.appRegistry.registerRole('Connect.AuthStrategy', AUTH_ROLE);
+      before(() => {
+        global.hadronApp = hadronApp;
+        global.hadronApp.appRegistry = appRegistry;
+        global.hadronApp.appRegistry.registerRole('Connect.AuthStrategy', AUTH_ROLE);
+      });
+
+      after(() => {
+        global.hadronApp.appRegistry.deregisterRole('Connect.AuthStrategy', AUTH_ROLE);
+      });
+
+      beforeEach(() => {
+        component = mount(
+          <ConnectionForm
+            currentConnection={connection}
+            isHostChanged={isHostChanged}
+            isPortChanged={isPortChanged}
+            isValid />
+        );
+      });
+
+      afterEach(() => {
+        component = null;
+      });
+
+      it('renders empry host input', () => {
+        const hostInput = component.find('HostInput');
+
+        expect(hostInput).to.be.present();
+        expect(hostInput.prop('hostname')).to.equal(undefined);
+        expect(hostInput.prop('isHostChanged')).to.equal(false);
+      });
+
+      it('renders empry port input', () => {
+        const portInput = component.find('PortInput');
+
+        expect(portInput).to.be.present();
+        expect(portInput.prop('port')).to.equal(undefined);
+        expect(portInput.prop('isPortChanged')).to.equal(false);
+      });
+
+      it('renders SRV input with false value', () => {
+        const srvInput = component.find('SRVInput');
+
+        expect(srvInput).to.be.present();
+        expect(srvInput.prop('isSrvRecord')).to.equal(false);
+      });
+
+      it('renders authentication section', () => {
+        const authentication = component.find('Authentication');
+
+        expect(authentication).to.be.present();
+        expect(authentication.prop('currentConnection')).to.deep.equal(connection);
+        expect(authentication.prop('isValid')).to.equal(true);
+      });
     });
 
-    after(() => {
-      global.hadronApp.appRegistry.deregisterRole('Connect.AuthStrategy', AUTH_ROLE);
-    });
+    context('when SRV input was toggled', () => {
+      const appRegistry = new AppRegistry();
+      const connection = {
+        authStrategy: 'MONGODB',
+        isSrvRecord: true,
+        readPreference: 'primaryPreferred',
+        attributes: { hostanme: 'localhost' }
+      };
+      const isHostChanged = true;
+      const isPortChanged = true;
+      const AUTH_ROLE = {
+        name: 'MONGODB',
+        component: TestComponent,
+        selectOption: { 'MONGODB': 'Username / Password' }
+      };
+      let component;
 
-    beforeEach(() => {
-      component = mount(
-        <ConnectionForm currentConnection={connection} isValid />
-      );
-    });
+      before(() => {
+        global.hadronApp = hadronApp;
+        global.hadronApp.appRegistry = appRegistry;
+        global.hadronApp.appRegistry.registerRole('Connect.AuthStrategy', AUTH_ROLE);
+      });
 
-    afterEach(() => {
-      component = null;
-    });
+      after(() => {
+        global.hadronApp.appRegistry.deregisterRole('Connect.AuthStrategy', AUTH_ROLE);
+      });
 
-    it('renders host input', () => {
-      const hostInput = component.find('HostInput');
+      beforeEach(() => {
+        component = mount(
+          <ConnectionForm
+            currentConnection={connection}
+            isHostChanged={isHostChanged}
+            isPortChanged={isPortChanged}
+            isValid />
+        );
+      });
 
-      expect(hostInput).to.be.present();
-    });
+      afterEach(() => {
+        component = null;
+      });
 
-    it('renders SRV input', () => {
-      const hostInput = component.find('SRVInput');
+      it('renders empry host input', () => {
+        expect(component.find('HostInput').prop('isHostChanged')).to.equal(true);
+      });
 
-      expect(hostInput).to.be.present();
-    });
+      it('renders empry port input', () => {
+        expect(component.find('PortInput')).to.be.not.present();
+      });
 
-    it('renders authentication section', () => {
-      const hostInput = component.find('Authentication');
+      it('renders SRV input with true value', () => {
+        const srvInput = component.find('SRVInput');
 
-      expect(hostInput).to.be.present();
+        expect(srvInput).to.be.present();
+        expect(srvInput.prop('isSrvRecord')).to.equal(true);
+      });
     });
   });
 
-  context('tab is More Options', () => {
+  context('when active tab is More Options', () => {
     const appRegistry = new AppRegistry();
     const connection = {
       authStrategy: 'MONGODB',
@@ -118,33 +196,23 @@ describe('ConnectionForm [Component]', () => {
     });
 
     it('renders replica set input', () => {
-      const hostInput = component.find('ReplicaSetInput');
-
-      expect(hostInput).to.be.present();
+      expect(component.find('ReplicaSetInput')).to.be.present();
     });
 
     it('renders read preference select', () => {
-      const hostInput = component.find('ReadPreferenceSelect');
-
-      expect(hostInput).to.be.present();
+      expect(component.find('ReadPreferenceSelect')).to.be.present();
     });
 
     it('renders SSLMethod input', () => {
-      const hostInput = component.find('SSLMethod');
-
-      expect(hostInput).to.be.present();
+      expect(component.find('SSLMethod')).to.be.present();
     });
 
     it('renders SSHTunnel input', () => {
-      const hostInput = component.find('SSHTunnel');
-
-      expect(hostInput).to.be.present();
+      expect(component.find('SSHTunnel')).to.be.present();
     });
 
     it('renders form actions', () => {
-      const hostInput = component.find('FormActions');
-
-      expect(hostInput).to.be.present();
+      expect(component.find('FormActions')).to.be.present();
     });
   });
 });

--- a/src/components/form/connection-string.jsx
+++ b/src/components/form/connection-string.jsx
@@ -10,7 +10,15 @@ import styles from '../connect.less';
 class ConnectionString extends React.Component {
   static displayName = 'ConnectionString';
 
-  static propTypes = { customUrl: PropTypes.string };
+  static propTypes = {
+    currentConnection: PropTypes.object.isRequired,
+    customUrl: PropTypes.string,
+    isValid: PropTypes.bool,
+    isConnected: PropTypes.bool,
+    errorMessage: PropTypes.string,
+    syntaxErrorMessage: PropTypes.string,
+    viewType: PropTypes.string
+  };
 
   render() {
     return (
@@ -20,7 +28,13 @@ class ConnectionString extends React.Component {
         <FormGroup separator>
           <ConnectionStringInput customUrl={this.props.customUrl} />
         </FormGroup>
-        <FormActions {...this.props } />
+        <FormActions
+          currentConnection={this.props.currentConnection}
+          isValid={this.props.isValid}
+          isConnected={this.props.isConnected}
+          errorMessage={this.props.errorMessage}
+          syntaxErrorMessage={this.props.syntaxErrorMessage}
+          viewType={this.props.viewType} />
       </form>
     );
   }

--- a/src/components/form/favorite-modal.jsx
+++ b/src/components/form/favorite-modal.jsx
@@ -4,7 +4,6 @@ import classnames from 'classnames';
 import { Modal } from 'react-bootstrap';
 import { ModalInput } from 'hadron-react-components';
 import { TextButton } from 'hadron-react-buttons';
-import Actions from 'actions';
 import FavoriteColorPicker from './favorite-color-picker';
 
 import styles from '../connect.less';
@@ -17,7 +16,9 @@ class FavoriteModal extends PureComponent {
 
   static propTypes = {
     currentConnection: PropTypes.object,
-    isModalVisible: PropTypes.bool.isRequired
+    deleteFavorite: PropTypes.func,
+    saveFavorite: PropTypes.func,
+    closeFavoriteModal: PropTypes.func
   }
 
   constructor(props) {
@@ -28,19 +29,11 @@ class FavoriteModal extends PureComponent {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      name: nextProps.currentConnection.name,
-      color: nextProps.currentConnection.color
-    });
-  }
-
   /**
    * Deletes a favorite.
    */
   onDeleteFavoriteClicked() {
-    Actions.onDeleteConnectionClicked(this.props.currentConnection);
-    Actions.hideFavoriteModal();
+    this.props.deleteFavorite(this.props.currentConnection);
   }
 
   /**
@@ -56,16 +49,14 @@ class FavoriteModal extends PureComponent {
    * Closes modal.
    */
   handleClose() {
-    Actions.hideFavoriteModal();
+    this.props.closeFavoriteModal();
   }
 
   /**
    * Saves the favorite.
    */
   handleSave() {
-    Actions.onCreateFavoriteClicked(this.state.name, this.state.color);
-    Actions.hideFavoriteModal();
-    Actions.showFavoriteMessage();
+    this.props.saveFavorite(this.state.name, this.state.color);
   }
 
   /**
@@ -126,7 +117,7 @@ class FavoriteModal extends PureComponent {
   render() {
     return (
       <Modal
-        show={this.props.isModalVisible}
+        show
         backdrop="static"
         dialogClassName={classnames(styles['favorite-modal'])}
       >

--- a/src/components/form/favorite-modal.spec.js
+++ b/src/components/form/favorite-modal.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import FavoriteModal from './favorite-modal';
 
 describe('FavoriteModal [Component]', () => {
@@ -11,14 +11,18 @@ describe('FavoriteModal [Component]', () => {
       attributes: { hostanme: 'localhost' },
       isFavorite: false
     };
-    const isModalVisible = true;
+    const deleteFavorite = sinon.spy();
+    const saveFavorite = sinon.spy();
+    const closeFavoriteModal = sinon.spy();
     let component;
 
     beforeEach(() => {
-      component = shallow(
+      component = mount(
         <FavoriteModal
           currentConnection={connection}
-          isModalVisible={isModalVisible} />
+          deleteFavorite={deleteFavorite}
+          saveFavorite={saveFavorite}
+          closeFavoriteModal={closeFavoriteModal} />
       );
     });
 
@@ -43,14 +47,18 @@ describe('FavoriteModal [Component]', () => {
       attributes: { hostanme: 'localhost' },
       isFavorite: true
     };
-    const isModalVisible = true;
+    const deleteFavorite = sinon.spy();
+    const saveFavorite = sinon.spy();
+    const closeFavoriteModal = sinon.spy();
     let component;
 
     beforeEach(() => {
-      component = shallow(
+      component = mount(
         <FavoriteModal
           currentConnection={connection}
-          isModalVisible={isModalVisible} />
+          deleteFavorite={deleteFavorite}
+          saveFavorite={saveFavorite}
+          closeFavoriteModal={closeFavoriteModal} />
       );
     });
 
@@ -64,6 +72,49 @@ describe('FavoriteModal [Component]', () => {
       expect(component.find('TextButton[dataTestId="cancel-favorite-button"]')).to.be.present();
       expect(component.find('TextButton[dataTestId="create-favorite-button"]')).to.be.present();
       expect(component.find('TextButton[dataTestId="delete-favorite-button"]')).to.be.present();
+    });
+  });
+
+  context('when modal is displayed', () => {
+    const connection = {
+      authStrategy: 'MONGODB',
+      isSrvRecord: false,
+      readPreference: 'primaryPreferred',
+      attributes: { hostanme: 'localhost' },
+      isFavorite: true
+    };
+    const deleteFavorite = sinon.spy();
+    const saveFavorite = sinon.spy();
+    const closeFavoriteModal = sinon.spy();
+    let component;
+
+    beforeEach(() => {
+      component = mount(
+        <FavoriteModal
+          currentConnection={connection}
+          deleteFavorite={deleteFavorite}
+          saveFavorite={saveFavorite}
+          closeFavoriteModal={closeFavoriteModal} />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('calls save favorite on save button click', () => {
+      component.find('TextButton[dataTestId="create-favorite-button"]').simulate('click');
+      expect(saveFavorite.calledOnce).to.equal(true);
+    });
+
+    it('calls delete favorite on delete button click', () => {
+      component.find('TextButton[dataTestId="delete-favorite-button"]').simulate('click');
+      expect(deleteFavorite.calledOnce).to.equal(true);
+    });
+
+    it('calls close favorite on cancel button click', () => {
+      component.find('TextButton[dataTestId="cancel-favorite-button"]').simulate('click');
+      expect(closeFavoriteModal.calledOnce).to.equal(true);
     });
   });
 });

--- a/src/components/form/is-favorite-pill.jsx
+++ b/src/components/form/is-favorite-pill.jsx
@@ -21,6 +21,35 @@ class IsFavoritePill extends PureComponent {
   }
 
   /**
+   * Deletes the current favorite.
+   *
+   * @param {Object} connection - The current connection.
+   */
+  deleteFavorite(connection) {
+    Actions.onDeleteConnectionClicked(connection);
+    Actions.hideFavoriteModal();
+  }
+
+  /**
+   * Closes the favorite modal.
+   */
+  closeFavoriteModal() {
+    Actions.hideFavoriteModal();
+  }
+
+  /**
+   * Saves the current connection to favorites.
+   *
+   * @param {String} name - The favorite name.
+   * @param {String} color - The favorite color.
+   */
+  saveFavorite(name, color) {
+    Actions.onCreateFavoriteClicked(name, color);
+    Actions.hideFavoriteModal();
+    Actions.showFavoriteMessage();
+  }
+
+  /**
    * Shows modal when the favorite pill is clicked.
    *
    * @param {Object} evt - The click event.
@@ -29,6 +58,23 @@ class IsFavoritePill extends PureComponent {
     evt.preventDefault();
     evt.stopPropagation();
     Actions.showFavoriteModal();
+  }
+
+  /**
+   * Renders the favorite modal.
+   *
+   * @returns {React.Component}
+   */
+  renderFavoriteModal() {
+    if (this.props.isModalVisible) {
+      return (
+        <FavoriteModal
+          currentConnection={this.props.currentConnection}
+          deleteFavorite={this.deleteFavorite}
+          closeFavoriteModal={this.closeFavoriteModal}
+          saveFavorite={this.saveFavorite} />
+      );
+    }
   }
 
   /**
@@ -60,9 +106,7 @@ class IsFavoritePill extends PureComponent {
           &nbsp;FAVORITE
           <div className={className}>{this.props.savedMessage}</div>
         </a>
-        <FavoriteModal
-          currentConnection={this.props.currentConnection}
-          isModalVisible={this.props.isModalVisible} />
+        {this.renderFavoriteModal()}
       </div>
     );
   }

--- a/src/components/sidebar/favorites.spec.js
+++ b/src/components/sidebar/favorites.spec.js
@@ -5,46 +5,75 @@ import Favorites from './favorites';
 import styles from './sidebar.less';
 
 describe('Favorites [Component]', () => {
-  const favorites = [{ name: 'myconn', isFavorite: true }];
-  let component;
+  context('when the connection has no color', () => {
+    const favorites = [{ name: 'myconn', isFavorite: true }];
+    let component;
 
-  beforeEach(() => {
-    component = mount(
-      <Favorites currentConnection={{}} connections={favorites} />
-    );
+    beforeEach(() => {
+      component = mount(
+        <Favorites currentConnection={{}} connections={favorites} />
+      );
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('renders the wrapper div', () => {
+      const style = '.connect-sidebar-connections-favorites';
+
+      expect(component.find(style)).to.be.present();
+    });
+
+    it('renders the header', () => {
+      const style = `.${styles['connect-sidebar-header']}`;
+
+      expect(component.find(style)).to.be.present();
+    });
+
+    it('renders the favorites icon', () => {
+      const style = 'i.fa-star';
+
+      expect(component.find(style)).to.be.present();
+    });
+
+    it('renders the favorite name', () => {
+      const style = `.${styles['connect-sidebar-list-item-name']}`;
+
+      expect(component.find(style)).to.be.present();
+    });
+
+    it('renders the favorite lastUsed ', () => {
+      const style = `.${styles['connect-sidebar-list-item-last-used']}`;
+
+      expect(component.find(style)).to.be.present();
+    });
+
+    it('sets a default color for the right border ', () => {
+      const favorite = component.find(`.${styles['connect-sidebar-list-item']}`);
+
+      expect(favorite.prop('style')).to.deep.equal({});
+    });
   });
 
-  afterEach(() => {
-    component = null;
-  });
+  context('when the connection has a custom color', () => {
+    const favorites = [{ name: 'myconn', isFavorite: true, color: '#2c5f4a' }];
+    let component;
 
-  it('renders the wrapper div', () => {
-    const style = '.connect-sidebar-connections-favorites';
+    beforeEach(() => {
+      component = mount(
+        <Favorites currentConnection={{}} connections={favorites} />
+      );
+    });
 
-    expect(component.find(style)).to.be.present();
-  });
+    afterEach(() => {
+      component = null;
+    });
 
-  it('renders the header', () => {
-    const style = `.${styles['connect-sidebar-header']}`;
+    it('sets a default color for the right border ', () => {
+      const favorite = component.find(`.${styles['connect-sidebar-list-item']}`);
 
-    expect(component.find(style)).to.be.present();
-  });
-
-  it('renders the favorites icon', () => {
-    const style = 'i.fa-star';
-
-    expect(component.find(style)).to.be.present();
-  });
-
-  it('renders the favorite name', () => {
-    const style = `.${styles['connect-sidebar-list-item-name']}`;
-
-    expect(component.find(style)).to.be.present();
-  });
-
-  it('renders the favorite lastUsed ', () => {
-    const style = `.${styles['connect-sidebar-list-item-last-used']}`;
-
-    expect(component.find(style)).to.be.present();
+      expect(favorite.prop('style')).to.deep.equal({ borderRight: '5px solid #2c5f4a' });
+    });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import SSLServerValidation from 'components/form/ssl-server-validation';
 import SSLServerClientValidation from 'components/form/ssl-server-client-validation';
 import SSHTunnelIdentityFileValidation from 'components/form/ssh-tunnel-identity-file-validation';
 import SSHTunnelPasswordValidation from 'components/form/ssh-tunnel-password-validation';
+import FavoriteModal from 'components/form/favorite-modal';
 
 /**
  * A sample role for the component.
@@ -163,5 +164,6 @@ export {
   SSHTunnelIdentityFileValidation,
   SSHTunnelPasswordValidation,
   activate,
-  deactivate
+  deactivate,
+  FavoriteModal
 };

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -335,12 +335,18 @@ const Store = Reflux.createStore({
             const name = currentConnection.name;
             const color = currentConnection.color;
             const isFavorite = currentConnection.isFavorite;
+            const driverUrl = currentConnection.driverUrl;
+            let connection;
 
-            const connection = merge(
-              currentConnection,
-              parsedConnection,
-              { name, color, isFavorite, lastUsed }
-            );
+            if (isFavorite && driverUrl !== parsedConnection.driverUrl) {
+              connection = parsedConnection;
+            } else {
+              connection = merge(
+                currentConnection,
+                parsedConnection,
+                { name, color, isFavorite, lastUsed }
+              );
+            }
 
             this._connect(connection);
           }
@@ -366,8 +372,7 @@ const Store = Reflux.createStore({
   onCreateFavoriteClicked(name, color) {
     const currentConnection = this.state.currentConnection;
     const connections = this.state.connections;
-    const isFavorite = currentConnection;
-
+    const isFavorite = currentConnection.isFavorite;
     const currentRecent = connections.find((recent) => (
       recent === currentConnection &&
       recent.isFavorite === false

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -11,7 +11,6 @@ const StateMixin = require('reflux-state-mixin');
 const ipc = require('hadron-ipc');
 const userAgent = navigator.userAgent.toLowerCase();
 const electron = require('electron');
-// const FavoriteModal = require('../components/form/favorite-modal');
 
 /**
  * A default driverUrl.
@@ -98,38 +97,11 @@ const Store = Reflux.createStore({
     this.StatusActions = appRegistry.getAction('Status.Actions');
     this.appRegistry = appRegistry;
 
-    appRegistry.on('save-favorite', (name, color, connection) => {
-      appRegistry.getAction('Connect.Actions').saveFavorite(name, color, connection);
+    appRegistry.on('clear-current-favorite', () => {
+      const ConnectStore = appRegistry.getStore('Connect.Store');
+
+      ConnectStore.state.currentConnection = new Connection();
     });
-
-    appRegistry.on('delete-favorite', (connection) => {
-      appRegistry.getAction('Connect.Actions').deleteFavorite(connection);
-    });
-  },
-
-  /**
-   * Saves the favorite after connecting.
-   *
-   * @param {String} name - The favorite name.
-   * @param {String} color - The favorite color.
-   * @param {Object} connection - The connection.
-   */
-  saveFavorite(name, color, connection) {
-    connection.isFavorite = true;
-    connection.name = name;
-    connection.color = color;
-    connection.save();
-    global.hadronApp.appRegistry.emit('change-favorite-attributes', name, color, true);
-  },
-
-  /**
-   * Deletes the favorite after connecting.
-   *
-   * @param {Object} connection - The connection.
-   */
-  deleteFavorite(connection) {
-    connection.destroy();
-    global.hadronApp.appRegistry.emit('change-favorite-attributes', '', undefined, false);
   },
 
   /**

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -10,6 +10,7 @@ const StateMixin = require('reflux-state-mixin');
 const ipc = require('hadron-ipc');
 const userAgent = navigator.userAgent.toLowerCase();
 const electron = require('electron');
+// const FavoriteModal = require('../components/form/favorite-modal');
 
 /**
  * A default driverUrl.
@@ -95,6 +96,37 @@ const Store = Reflux.createStore({
 
     this.StatusActions = appRegistry.getAction('Status.Actions');
     this.appRegistry = appRegistry;
+
+    appRegistry.on('save-favorite', (name, color, connection) => {
+      appRegistry.getAction('Connect.Actions').saveFavorite(name, color, connection);
+    });
+
+    appRegistry.on('delete-favorite', (connection) => {
+      appRegistry.getAction('Connect.Actions').deleteFavorite(connection);
+    });
+  },
+
+  /**
+   * Saves the favorite after connecting.
+   *
+   * @param {String} name - The favorite name.
+   * @param {String} color - The favorite color.
+   * @param {Object} connection - The connection.
+   */
+  saveFavorite(name, color, connection) {
+    connection.isFavorite = true;
+    connection.name = name;
+    connection.color = color;
+    connection.save();
+  },
+
+  /**
+   * Deletes the favorite after connecting.
+   *
+   * @param {Object} connection - The connection.
+   */
+  deleteFavorite(connection) {
+    connection.destroy();
   },
 
   /**
@@ -219,7 +251,7 @@ const Store = Reflux.createStore({
           .filter((connection) => connection.isFavorite)
           .find((favorite) => (favorite === this.state.currentConnection));
 
-        Actions.onFavoriteSelected(currentFavorite);
+        this.onFavoriteSelected(currentFavorite);
         this.trigger(this.state);
       } else if (customUrl === driverUrl) {
         this.state.isHostChanged = true;


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- Enable `save / edit / delete / color change` after saving connection to favorites
- Transform `FavoriteModal` to a pure component to reuse this component in other plugins
- Transform `FavoriteModal` to uncontrolled components to reuse this component in Redux based plugins
- Export `FavoriteModal` to reuse this component in other plugins eg `compass-sidebar`
- Ensure that all the time the same connection object is used to avoid favorite duplicates. One of the steps to do so is to use `lodash.merge` that recursively merges own and inherited enumerable string keyed properties of source objects into the destination object.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
