### PR TITLE
COMPASS-4089: uses a real password when builds a driverUrl

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -304,22 +304,25 @@ const Store = Reflux.createStore({
    */
   onConnectClicked() {
     const currentConnection = this.state.currentConnection;
+    let url = this.state.currentConnection.driverUrl;
 
     // We replace custom appname with proper appname
     // to avoid sending malicious value to the server
     currentConnection.appname = electron.remote.app.getName();
 
     if (this.state.viewType === 'connectionString') {
-      const customUrl = this.state.customUrl || DEFAULT_DRIVER_URL;
+      if (this.state.isURIEditable) {
+        url = this.state.customUrl || DEFAULT_DRIVER_URL;
+      }
 
       this.StatusActions.showIndeterminateProgressBar();
 
-      if (!Connection.isURI(customUrl)) {
+      if (!Connection.isURI(url)) {
         this._setSyntaxErrorMessage(
           'Invalid schema, expected `mongodb` or `mongodb+srv`'
         );
       } else {
-        Connection.from(customUrl, (error, parsedConnection) => {
+        Connection.from(url, (error, parsedConnection) => {
           if (error) {
             this._setSyntaxErrorMessage(error.message);
           } else {

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -304,16 +304,15 @@ const Store = Reflux.createStore({
    */
   onConnectClicked() {
     const currentConnection = this.state.currentConnection;
-    let url = this.state.currentConnection.driverUrl;
 
     // We replace custom appname with proper appname
     // to avoid sending malicious value to the server
     currentConnection.appname = electron.remote.app.getName();
 
     if (this.state.viewType === 'connectionString') {
-      if (this.state.isURIEditable) {
-        url = this.state.customUrl || DEFAULT_DRIVER_URL;
-      }
+      const url = this.state.isURIEditable
+        ? this.state.customUrl || DEFAULT_DRIVER_URL
+        : this.state.currentConnection.driverUrl;
 
       this.StatusActions.showIndeterminateProgressBar();
 


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
When a user clicks on a favorite, the connection string field is disabled as expected but then when the user clicks connect it does not work. It happens because a password is hidden in the field and parser uses starts instead of a proper password therefore auth fails. In the case of read-only URL use driverUrl that already saved for the current favorite instead of safeUrl.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
