### PR TITLE
COMPASS-4150: handle password when switching views

### DIFF
--- a/src/components/form/form-actions.jsx
+++ b/src/components/form/form-actions.jsx
@@ -170,16 +170,18 @@ class FormActions extends React.Component {
    * @returns {React.Component}
    */
   renderEditURI = () => {
-    return (
-      <button
-        type="submit"
-        name="editUrl"
-        className="btn btn-sm btn-default"
-        onClick={this.onEditURIClicked.bind(this)}
-      >
-        Edit
-      </button>
-    );
+    if (this.props.viewType === 'connectionString') {
+      return (
+        <button
+          type="submit"
+          name="editUrl"
+          className="btn btn-sm btn-default"
+          onClick={this.onEditURIClicked.bind(this)}
+        >
+          Edit
+        </button>
+      );
+    }
   };
 
   /**
@@ -188,7 +190,11 @@ class FormActions extends React.Component {
    * @returns {React.Component}
    */
   renderHideURI = () => {
-    if (this.props.isSavedConnection && !this.props.hasUnsavedChanges) {
+    if (
+      this.props.isSavedConnection &&
+      !this.props.hasUnsavedChanges &&
+      this.props.viewType === 'connectionString'
+    ) {
       return (
         <button
           type="submit"

--- a/src/components/form/form-actions.spec.js
+++ b/src/components/form/form-actions.spec.js
@@ -215,6 +215,12 @@ describe('FormActions [Component]', () => {
 
           expect(editButton).to.be.not.present();
         });
+
+        it('does not render the hide button', () => {
+          const hideButton = component.find('button[name="hideUrl"]');
+
+          expect(hideButton).to.be.not.present();
+        });
       });
     });
 

--- a/src/components/form/form-actions.spec.js
+++ b/src/components/form/form-actions.spec.js
@@ -177,6 +177,7 @@ describe('FormActions [Component]', () => {
         const connection = { name: 'myconnection' };
         const isConnected = false;
         const viewType = 'connectionForm';
+        const isURIEditable = true;
         let component;
 
         beforeEach(() => {
@@ -185,6 +186,7 @@ describe('FormActions [Component]', () => {
               currentConnection={connection}
               isConnected={isConnected}
               viewType={viewType}
+              isURIEditable={isURIEditable}
               isValid
             />
           );
@@ -206,6 +208,12 @@ describe('FormActions [Component]', () => {
 
         it('renders the connect button', () => {
           expect(component.find('button[name="connect"]')).to.be.present();
+        });
+
+        it('does not render the edit button', () => {
+          const editButton = component.find('button[name="editUrl"]');
+
+          expect(editButton).to.be.not.present();
         });
       });
     });

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -394,7 +394,13 @@ const Store = Reflux.createStore({
     const connection = this.state.connections[this.state.currentConnection._id];
 
     this.state.currentConnection.set(connection);
-    this.state.customUrl = this.state.currentConnection.driverUrl;
+
+    if (this.state.isURIEditable) {
+      this.state.customUrl = this.state.currentConnection.driverUrl;
+    } else {
+      this.state.customUrl = this.state.currentConnection.safeUrl;
+    }
+
     this.state.hasUnsavedChanges = false;
     this.trigger(this.state);
   },

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -222,30 +222,30 @@ const Store = Reflux.createStore({
   onChangeViewClicked(viewType) {
     const currentConnection = this.state.currentConnection;
     const driverUrl = currentConnection.driverUrl;
-    const customUrl = this.state.customUrl;
+    const url = this.state.isURIEditable ? this.state.customUrl : driverUrl;
     const isValid = this.state.isValid;
     const currentSaved = this.state.connections[currentConnection._id];
 
     this.state.viewType = viewType;
 
+    // Target view
     if (viewType === 'connectionForm') {
-      // Target view
-      if (!currentSaved && customUrl === driverUrl) {
+      if (!currentSaved && url === driverUrl) {
         this.state.isHostChanged = true;
         this.state.isPortChanged = true;
         this.trigger(this.state);
-      } else if (customUrl === '') {
+      } else if (url === '') {
         this.state.isHostChanged = false;
         this.state.isPortChanged = false;
         this._clearForm();
         this._clearConnection();
-      } else if (!Connection.isURI(customUrl)) {
+      } else if (!Connection.isURI(url)) {
         this._clearConnection();
         this.trigger(this.state);
       } else {
         this.StatusActions.showIndeterminateProgressBar();
 
-        Connection.from(customUrl, (error, parsedConnection) => {
+        Connection.from(url, (error, parsedConnection) => {
           this.StatusActions.done();
 
           if (!error) {
@@ -261,7 +261,7 @@ const Store = Reflux.createStore({
               this._setTlsAttributes(currentSaved, currentConnection);
             }
 
-            if (customUrl.match(/[?&]ssl=true/i)) {
+            if (url.match(/[?&]ssl=true/i)) {
               currentConnection.sslMethod = 'SYSTEMCA';
             }
 
@@ -286,7 +286,7 @@ const Store = Reflux.createStore({
         isValid &&
         (this.state.isHostChanged === true || this.state.isPortChanged === true)
           ? driverUrl
-          : customUrl;
+          : url;
       this.trigger(this.state);
     }
   },

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -282,11 +282,15 @@ const Store = Reflux.createStore({
         });
       }
     } else {
-      this.state.customUrl =
+      if (!this.state.isURIEditable) {
+        this.state.customUrl = this.state.currentConnection.safeUrl;
+      } else if (
         isValid &&
         (this.state.isHostChanged === true || this.state.isPortChanged === true)
-          ? driverUrl
-          : url;
+      ) {
+        this.state.customUrl = driverUrl;
+      }
+
       this.trigger(this.state);
     }
   },

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -990,9 +990,14 @@ const Store = Reflux.createStore({
   _saveFavorite() {
     const currentConnection = this.state.currentConnection;
     const isFavorite = currentConnection.isFavorite;
+    let url = this.state.customUrl;
 
     if (isFavorite) {
       this.state.savedMessage = 'Favorite is updated';
+    }
+
+    if (!this.state.isURIEditable) {
+      url = currentConnection.driverUrl;
     }
 
     currentConnection.isFavorite = true;
@@ -1000,11 +1005,11 @@ const Store = Reflux.createStore({
     this.state.isURIEditable = false;
 
     if (this.state.viewType === 'connectionString') {
-      Connection.from(this.state.customUrl, (error, parsedConnection) => {
+      Connection.from(url, (error, parsedConnection) => {
         if (!error) {
           currentConnection.set(this._getPoorAttributes(parsedConnection));
 
-          if (this.state.customUrl.match(/[?&]ssl=true/i)) {
+          if (url.match(/[?&]ssl=true/i)) {
             currentConnection.sslMethod = 'SYSTEMCA';
           }
 

--- a/test/renderer/stores/index.spec.js
+++ b/test/renderer/stores/index.spec.js
@@ -1022,51 +1022,92 @@ describe('Store', () => {
     context('when a form is valid', () => {
       context('when a current viewType is connectionString', () => {
         context('when a current connection string is valid', () => {
-          const connection = new Connection();
+          context('when a connection string is editable', () => {
+            const connection = new Connection();
 
-          beforeEach(() => {
-            Store.state.isValid = true;
-            Store.state.viewType = 'connectionString';
-            Store.state.customUrl = 'mongodb://server.example.com/';
-            Store.StatusActions = {
-              showIndeterminateProgressBar: () => {},
-              done: () => {}
-            };
-            Store.state.currentConnection = connection;
-          });
-
-          it('sets the connectionForm viewType', (done) => {
-            const unsubscribe = Store.listen((state) => {
-              unsubscribe();
-              expect(state.viewType).to.equal('connectionForm');
-              done();
+            beforeEach(() => {
+              Store.state.isValid = true;
+              Store.state.viewType = 'connectionString';
+              Store.state.customUrl = 'mongodb://server.example.com/';
+              Store.StatusActions = {
+                showIndeterminateProgressBar: () => {},
+                done: () => {}
+              };
+              Store.state.currentConnection = connection;
+              Store.state.isURIEditable = true;
             });
 
-            Actions.onChangeViewClicked('connectionForm');
-          });
+            it('sets the connectionForm viewType', (done) => {
+              const unsubscribe = Store.listen((state) => {
+                unsubscribe();
+                expect(state.viewType).to.equal('connectionForm');
+                done();
+              });
 
-          it('sets the driverUrl', (done) => {
-            const driverUrl =
-              'mongodb://server.example.com:27017/?readPreference=primary&ssl=false';
-            const unsubscribe = Store.listen((state) => {
-              unsubscribe();
-              expect(state.currentConnection).to.exist;
-              expect(state.currentConnection.driverUrl).to.equal(driverUrl);
-              done();
+              Actions.onChangeViewClicked('connectionForm');
             });
 
-            Actions.onChangeViewClicked('connectionForm');
-          });
+            it('sets the driverUrl', (done) => {
+              const driverUrl =
+                'mongodb://server.example.com:27017/?readPreference=primary&ssl=false';
+              const unsubscribe = Store.listen((state) => {
+                unsubscribe();
+                expect(state.currentConnection).to.exist;
+                expect(state.currentConnection.driverUrl).to.equal(driverUrl);
+                done();
+              });
 
-          it('keeps the current connection id', (done) => {
-            const unsubscribe = Store.listen((state) => {
-              unsubscribe();
-              expect(state.currentConnection).to.exist;
-              expect(state.currentConnection._id).to.equal(connection._id);
-              done();
+              Actions.onChangeViewClicked('connectionForm');
             });
 
-            Actions.onChangeViewClicked('connectionForm');
+            it('keeps the current connection id', (done) => {
+              const unsubscribe = Store.listen((state) => {
+                unsubscribe();
+                expect(state.currentConnection).to.exist;
+                expect(state.currentConnection._id).to.equal(connection._id);
+                done();
+              });
+
+              Actions.onChangeViewClicked('connectionForm');
+            });
+          });
+
+          context('when a connection string is not editable', () => {
+            const connection = new Connection({
+              hostname: 'server.example.com',
+              port: 27017,
+              authStrategy: 'MONGODB',
+              mongodbUsername: 'user',
+              mongodbPassword: 'password'
+            });
+
+            beforeEach(() => {
+              Store.state.isValid = true;
+              Store.state.viewType = 'connectionString';
+              Store.state.customUrl =
+                'mongodb://user:*****@server.example.com:27017/?authSource=admin&readPreference=primary&ssl=false';
+              Store.state.driverUrl =
+                'mongodb://user:password@server.example.com:27017/?authSource=admin&readPreference=primary&ssl=false';
+              Store.StatusActions = {
+                showIndeterminateProgressBar: () => {},
+                done: () => {}
+              };
+              Store.state.currentConnection = connection;
+              Store.state.isURIEditable = false;
+            });
+
+            it('sets the driverUrl', (done) => {
+              const unsubscribe = Store.listen((state) => {
+                unsubscribe();
+                expect(state.currentConnection).to.exist;
+                expect(state.currentConnection.mongodbPassword).to.equal(
+                  'password'
+                );
+                done();
+              });
+
+              Actions.onChangeViewClicked('connectionForm');
+            });
           });
         });
 

--- a/test/renderer/stores/index.spec.js
+++ b/test/renderer/stores/index.spec.js
@@ -1096,7 +1096,7 @@ describe('Store', () => {
               Store.state.isURIEditable = false;
             });
 
-            it('sets the driverUrl', (done) => {
+            it('sets the real password for the current connection', (done) => {
               const unsubscribe = Store.listen((state) => {
                 unsubscribe();
                 expect(state.currentConnection).to.exist;


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Handle password while swithcing views:

- When switching to the connection form view do not display edit/hide buttons
- When a connection string is not editable when switching to the connection form view, use the real password to populate the input, do not use ***** value form the safe connection string.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
