### PR TITLE
feat(connect-form): Show validation error message instead of generic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -424,12 +424,11 @@
       }
     },
     "@mongodb-js/compass-auth-x509": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-auth-x509/-/compass-auth-x509-4.0.0.tgz",
-      "integrity": "sha512-OdUJnxxvrOpN7Be8aRXqlFrpRzjX+PrGlXdFYGcqPORRfbH226QT0Seh9L+Zq7nMxxGZvk0NYdjrPwtv/19MGg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-auth-x509/-/compass-auth-x509-4.1.0.tgz",
+      "integrity": "sha512-rR4sN9+pt4KTff62HTvN47WwAZ16hVmjP2JhOS0bDkILadUWMODkRaklT1ih1w3RcT12kf/5SfXufpVHs8BpyA==",
       "dev": true,
       "requires": {
-        "lodash.isempty": "^4.4.0",
         "react-tooltip": "^3.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@mongodb-js/compass-auth-kerberos": "^4.0.0",
     "@mongodb-js/compass-auth-ldap": "^4.0.0",
-    "@mongodb-js/compass-auth-x509": "^4.0.0",
+    "@mongodb-js/compass-auth-x509": "^4.1.0",
     "@mongodb-js/compass-status": "^4.0.0",
     "autoprefixer": "^9.4.6",
     "babel-cli": "^6.26.0",

--- a/src/components/modal/confirm-edit-connection-string.jsx
+++ b/src/components/modal/confirm-edit-connection-string.jsx
@@ -1,11 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import Actions from 'actions';
 import { Modal } from 'react-bootstrap';
 import { TextButton } from 'hadron-react-buttons';
-
-import styles from '../connect.less';
 
 /**
  * Question text.

--- a/src/components/modal/confirm-edit-connection-string.spec.js
+++ b/src/components/modal/confirm-edit-connection-string.spec.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 import ConfirmEditConnectionString from './confirm-edit-connection-string';
 
-import styles from '../connect.less';
-
 describe('ConfirmEditConnectionString [Component]', () => {
   let component;
 

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -359,9 +359,13 @@ const Store = Reflux.createStore({
         });
       }
     } else if (!currentConnection.isValid()) {
+      const validationError = currentConnection.validate(currentConnection);
+
       this.setState({
         isValid: false,
-        errorMessage: 'The required fields can not be empty'
+        errorMessage: validationError
+          ? validationError.message
+          : 'The required fields can not be empty'
       });
     } else {
       this.StatusActions.showIndeterminateProgressBar();
@@ -1019,9 +1023,13 @@ const Store = Reflux.createStore({
         }
       });
     } else if (!currentConnection.isValid()) {
+      const validationError = currentConnection.validate(currentConnection);
+
       this.setState({
         isValid: false,
-        errorMessage: 'The required fields can not be empty'
+        errorMessage: validationError
+          ? validationError.message
+          : 'The required fields can not be empty'
       });
     } else {
       this._saveConnection(currentConnection);


### PR DESCRIPTION
Previously, on a validation error, compass-connect would show the error message `The required fields can not be empty`
This could be confusing if the page of the form the user is on isn't the one with the fields missing, we can also be a bit more descriptive with our validations, since we generate descriptive errors for why the connection fails validation.

This PR makes the validation error message show in the bottom instead of the generic.
___

*Before:*
<img width="300" alt="Screen Shot 2020-12-03 at 12 16 36 PM" src="https://user-images.githubusercontent.com/1791149/101065279-f2b5cd00-3562-11eb-8e70-aae18d1a13f0.png">
*After:*
<img width="300" alt="Screen Shot 2020-12-03 at 12 15 56 PM" src="https://user-images.githubusercontent.com/1791149/101065302-fa757180-3562-11eb-9382-1e371402d3f2.png">

*Invalid username*
![invalid username](https://user-images.githubusercontent.com/1791149/101065358-10833200-3563-11eb-97ad-5fe1d8769c4c.gif)

*Optional x509*
![successfully connect no username](https://user-images.githubusercontent.com/1791149/101065392-1b3dc700-3563-11eb-83d1-16227ca688a2.gif)

Showing validation errors
![better descriptive errors](https://user-images.githubusercontent.com/1791149/101065408-20027b00-3563-11eb-8c0c-e9812b4c56c4.gif)

