### PR TITLE
fix: make port HTML 'number' input field COMPASS-4550

### DIFF
--- a/src/components/form/connection-form.spec.js
+++ b/src/components/form/connection-form.spec.js
@@ -54,7 +54,7 @@ describe('ConnectionForm [Component]', () => {
         component = null;
       });
 
-      it('renders empry host input', () => {
+      it('renders empty host input', () => {
         const hostInput = component.find('HostInput');
 
         expect(hostInput).to.be.present();
@@ -62,7 +62,7 @@ describe('ConnectionForm [Component]', () => {
         expect(hostInput.prop('isHostChanged')).to.equal(false);
       });
 
-      it('renders empry port input', () => {
+      it('renders empty port input', () => {
         const portInput = component.find('PortInput');
 
         expect(portInput).to.be.present();
@@ -127,11 +127,11 @@ describe('ConnectionForm [Component]', () => {
         component = null;
       });
 
-      it('renders empry host input', () => {
+      it('renders empty host input', () => {
         expect(component.find('HostInput').prop('isHostChanged')).to.equal(true);
       });
 
-      it('renders empry port input', () => {
+      it('renders empty port input', () => {
         expect(component.find('PortInput')).to.be.not.present();
       });
 

--- a/src/components/form/form-input.js
+++ b/src/components/form/form-input.js
@@ -19,7 +19,8 @@ class FormInput extends React.PureComponent {
     placeholder: PropTypes.string,
     value: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
     type: PropTypes.string,
-    error: PropTypes.bool
+    error: PropTypes.bool,
+    otherInputAttributes: PropTypes.object
   };
 
   /**
@@ -79,7 +80,8 @@ class FormInput extends React.PureComponent {
           onBlur={this.props.blurHandler}
           value={this.props.value}
           className={classnames(styles['form-control'])}
-          type={this.props.type || 'text'} />
+          type={this.props.type || 'text'}
+          {...this.otherInputAttributes} />
       </div>
     );
   }

--- a/src/components/form/port-input.jsx
+++ b/src/components/form/port-input.jsx
@@ -39,7 +39,8 @@ class PortInput extends React.PureComponent {
         placeholder="27017"
         changeHandler={this.onPortChanged.bind(this)}
         value={this.getPort()}
-        type="number" />
+        type="number"
+        otherInputAttributes={{min: 1, max: 65536}} />
     );
   }
 }

--- a/src/components/form/port-input.jsx
+++ b/src/components/form/port-input.jsx
@@ -7,7 +7,7 @@ import FormInput from './form-input';
 class PortInput extends React.PureComponent {
   static displayName = 'PortInput';
 
-  static propTypes = { port: PropTypes.any, isPortChanged: PropTypes.bool };
+  static propTypes = { port: PropTypes.number, isPortChanged: PropTypes.bool };
 
   /**
    * Changes port.
@@ -15,7 +15,7 @@ class PortInput extends React.PureComponent {
    * @param {Object} evt - evt.
    */
   onPortChanged(evt) {
-    Actions.onPortChanged(evt.target.value);
+    Actions.onPortChanged(+evt.target.value);
   }
 
   /**
@@ -25,10 +25,10 @@ class PortInput extends React.PureComponent {
    */
   getPort() {
     if (this.props.isPortChanged === false) {
-      return '';
+      return 27017;
     }
 
-    return this.props.port;
+    return +this.props.port;
   }
 
   render() {
@@ -38,7 +38,8 @@ class PortInput extends React.PureComponent {
         name="port"
         placeholder="27017"
         changeHandler={this.onPortChanged.bind(this)}
-        value={this.getPort()} />
+        value={this.getPort()}
+        type="number" />
     );
   }
 }

--- a/src/components/form/port-input.spec.js
+++ b/src/components/form/port-input.spec.js
@@ -16,6 +16,7 @@ describe('PortInput [Component]', () => {
 
   it('renders the port', () => {
     expect(component.find('input[name="port"]')).to.have.value('27018');
+    expect(component.find('input[name="port"]').prop('type')).to.equal('number');
   });
 
   it('renders the port placeholder', () => {

--- a/src/components/form/ssh-tunnel-identity-file-validation.jsx
+++ b/src/components/form/ssh-tunnel-identity-file-validation.jsx
@@ -150,6 +150,7 @@ class SSHTunnelIdentityFileValidation extends React.Component {
           error={this.getPortError()}
           changeHandler={this.onSSHTunnelPortChanged.bind(this)}
           value={this.getPort()}
+          type="number"
         />
         <FormInput
           label="SSH Username"

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -628,7 +628,7 @@ const Store = Reflux.createStore({
    * @param {String} port - The port.
    */
   onPortChanged(port) {
-    this.state.currentConnection.port = port.trim();
+    this.state.currentConnection.port = port;
     this.state.isPortChanged = true;
     this.trigger(this.state);
   },

--- a/test/renderer/stores/index.spec.js
+++ b/test/renderer/stores/index.spec.js
@@ -292,24 +292,11 @@ describe('Store', () => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
         expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.port).to.equal('27018');
+        expect(state.currentConnection.port).to.equal(27018);
         done();
       });
 
-      Actions.onPortChanged('27018');
-    });
-
-    context('when it contains trailing spaces', () => {
-      it('trims the whitespace', (done) => {
-        const unsubscribe = Store.listen((state) => {
-          unsubscribe();
-          expect(state.currentConnection).to.exist;
-          expect(state.currentConnection.port).to.equal('27018');
-          done();
-        });
-
-        Actions.onPortChanged('27018  ');
-      });
+      Actions.onPortChanged(27018);
     });
   });
 


### PR DESCRIPTION
See COMPASS-4550
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [x] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->
https://github.com/mongodb-js/connection-model/pull/341

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
