### PR TITLE
chore: update connection-model to 19.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12866,9 +12866,9 @@
       }
     },
     "mongodb-connection-model": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-16.1.4.tgz",
-      "integrity": "sha512-QxLAuqlhxTb9b3ErklkIwx8ClPcrgQ1yMh/G7ARDqI8a/c4EFnBgbzRmtPa9XKgX30Yu1Ur7NM4RzDm4V2V3Sg==",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-19.0.1.tgz",
+      "integrity": "sha512-wxCkgmjGkEKGdxdIDbPcZuuyRfnGCRj6tsorgqZFGyarKkxM9wpNbUKP2ChJPwW5AHlfROOhE1IF4RdMsauQeA==",
       "dev": true,
       "requires": {
         "ampersand-model": "^8.0.0",
@@ -12876,10 +12876,9 @@
         "async": "^3.1.0",
         "debug": "^4.1.1",
         "lodash": "^4.17.15",
-        "mongodb": "^3.5.9",
         "raf": "^3.4.1",
         "ssh2": "^0.8.7",
-        "storage-mixin": "^3.3.3"
+        "storage-mixin": "^3.3.4"
       },
       "dependencies": {
         "async": {
@@ -12889,12 +12888,12 @@
           "dev": true
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -12902,6 +12901,26 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "storage-mixin": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/storage-mixin/-/storage-mixin-3.3.4.tgz",
+          "integrity": "sha512-NUD/loAAp2Enxqn28N4n5koJQFTIcN96AaAo8YFEut0tznR377oWrvd5ezOZTesRYbXKB5gKjMdK1e+IMpiE9Q==",
+          "dev": true,
+          "requires": {
+            "ampersand-model": "^8.0.1",
+            "ampersand-rest-collection": "^6.0.0",
+            "ampersand-sync": "^5.1.0",
+            "async": "^3.1.0",
+            "debug": "^4.1.1",
+            "hadron-ipc": "^1.1.0",
+            "keytar": "^5.0.0",
+            "localforage": "^1.7.3",
+            "lodash": "^4.17.15",
+            "rimraf": "^3.0.0",
+            "uuid": "^3.3.3",
+            "write-file-atomic": "^3.0.1"
+          }
         }
       }
     },
@@ -12930,6 +12949,16 @@
           "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
           "dev": true
         },
+        "bl": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -12939,11 +12968,64 @@
             "ms": "^2.1.1"
           }
         },
+        "mongodb-connection-model": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-16.1.8.tgz",
+          "integrity": "sha512-PhlfLYZhicERFhFC767SdN52VpTv0ZN+GU31lRqlCfljnaKuDuocytX4XhNupCSy0c6dKrNCoP+K3fDucevJYg==",
+          "dev": true,
+          "requires": {
+            "ampersand-model": "^8.0.0",
+            "ampersand-rest-collection": "^6.0.0",
+            "async": "^3.1.0",
+            "debug": "^4.1.1",
+            "lodash": "^4.17.15",
+            "mongodb": "^3.6.1",
+            "raf": "^3.4.1",
+            "ssh2": "^0.8.7",
+            "storage-mixin": "^3.3.4"
+          },
+          "dependencies": {
+            "mongodb": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+              "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+              "dev": true,
+              "requires": {
+                "bl": "^2.2.1",
+                "bson": "^1.1.4",
+                "denque": "^1.4.1",
+                "require_optional": "^1.0.1",
+                "safe-buffer": "^5.1.2",
+                "saslprep": "^1.0.0"
+              }
+            }
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "storage-mixin": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/storage-mixin/-/storage-mixin-3.3.4.tgz",
+          "integrity": "sha512-NUD/loAAp2Enxqn28N4n5koJQFTIcN96AaAo8YFEut0tznR377oWrvd5ezOZTesRYbXKB5gKjMdK1e+IMpiE9Q==",
+          "dev": true,
+          "requires": {
+            "ampersand-model": "^8.0.1",
+            "ampersand-rest-collection": "^6.0.0",
+            "ampersand-sync": "^5.1.0",
+            "async": "^3.1.0",
+            "debug": "^4.1.1",
+            "hadron-ipc": "^1.1.0",
+            "keytar": "^5.0.0",
+            "localforage": "^1.7.3",
+            "lodash": "^4.17.15",
+            "rimraf": "^3.0.0",
+            "uuid": "^3.3.3",
+            "write-file-atomic": "^3.0.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "mocha": "^7.0.1",
     "mocha-webpack": "^2.0.0-beta.0",
     "moment": "^2.10.6",
-    "mongodb-connection-model": "^16.1.4",
+    "mongodb-connection-model": "^19.0.1",
     "mongodb-data-service": "^16.8.1",
     "mongodb-js-precommit": "^2.0.0",
     "mongodb-shell-to-url": "^0.1.0",


### PR DESCRIPTION
## Description
This just updates the referenced `connection-model` version to the latest `19.0.1` that is also used in Compass itself. Just to get some recent version as compared to the old `16.x`.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [ ] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
