### PR TITLE
fix: Hide progress bar on invalid connection string connect attempt COMPASS-4202

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -267,12 +267,16 @@ const Store = Reflux.createStore({
    * In case of connecting via the form we can skip a parsing stage and
    * validate instead the existing connection object.
    */
-  onConnectClicked() {
+  async onConnectClicked() {
+    this.StatusActions.showIndeterminateProgressBar();
+
     if (this.state.viewType === CONNECTION_STRING_VIEW) {
-      this._connectWithConnectionString();
+      await this._connectWithConnectionString();
     } else if (this.state.viewType === CONNECTION_FORM_VIEW) {
-      this._connectWithConnectionForm();
+      await this._connectWithConnectionForm();
     }
+
+    this.StatusActions.done();
   },
 
   /**
@@ -872,7 +876,6 @@ const Store = Reflux.createStore({
         connectedDataService
       );
     } catch (error) {
-      this.StatusActions.done();
       this.setState({
         isValid: false,
         errorMessage: error.message,
@@ -897,7 +900,6 @@ const Store = Reflux.createStore({
           : 'The required fields can not be empty'
       });
     } else {
-      this.StatusActions.showIndeterminateProgressBar();
       await this._connect(currentConnection);
     }
   },
@@ -915,8 +917,6 @@ const Store = Reflux.createStore({
     const url = this.state.isURIEditable
       ? this.state.customUrl || DEFAULT_DRIVER_URL
       : this.state.currentConnection.driverUrl;
-
-    this.StatusActions.showIndeterminateProgressBar();
 
     if (!Connection.isURI(url)) {
       this._setSyntaxErrorMessage(

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -270,13 +270,21 @@ const Store = Reflux.createStore({
   async onConnectClicked() {
     this.StatusActions.showIndeterminateProgressBar();
 
-    if (this.state.viewType === CONNECTION_STRING_VIEW) {
-      await this._connectWithConnectionString();
-    } else if (this.state.viewType === CONNECTION_FORM_VIEW) {
-      await this._connectWithConnectionForm();
+    try {
+      if (this.state.viewType === CONNECTION_STRING_VIEW) {
+        await this._connectWithConnectionString();
+      } else if (this.state.viewType === CONNECTION_FORM_VIEW) {
+        await this._connectWithConnectionForm();
+      }
+    } catch (error) {
+      this.setState({
+        isValid: false,
+        errorMessage: error.message,
+        syntaxErrorMessage: null
+      });
+    } finally {
+      this.StatusActions.done();
     }
-
-    this.StatusActions.done();
   },
 
   /**

--- a/test/renderer/stores/index.spec.js
+++ b/test/renderer/stores/index.spec.js
@@ -1802,7 +1802,10 @@ describe('Store', () => {
         Store.state.currentConnection = parsedConnection;
         Store.trigger(Store.state);
       };
-      Store.StatusActions = { showIndeterminateProgressBar: () => {} };
+      Store.StatusActions = {
+        done: () => {},
+        showIndeterminateProgressBar: () => {}
+      };
     });
 
     it('uses a real password when builds a driverUrl', (done) => {
@@ -1815,6 +1818,22 @@ describe('Store', () => {
       });
 
       Actions.onConnectClicked();
+    });
+
+    it('shows and hides the progress bar', async() => {
+      const spyShow = sinon.spy(
+        Store.StatusActions,
+        'showIndeterminateProgressBar'
+      );
+      const spyDone = sinon.spy(
+        Store.StatusActions,
+        'done'
+      );
+
+      await Store.onConnectClicked();
+
+      expect(spyShow.calledOnce).to.equal(true);
+      expect(spyDone.calledOnce).to.equal(true);
     });
   });
 

--- a/test/renderer/stores/index.spec.js
+++ b/test/renderer/stores/index.spec.js
@@ -1808,6 +1808,10 @@ describe('Store', () => {
       };
     });
 
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it('uses a real password when builds a driverUrl', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
@@ -1828,6 +1832,28 @@ describe('Store', () => {
       const spyDone = sinon.spy(
         Store.StatusActions,
         'done'
+      );
+
+      await Store.onConnectClicked();
+
+      expect(spyShow.calledOnce).to.equal(true);
+      expect(spyDone.calledOnce).to.equal(true);
+    });
+
+    it('shows and hides the progress bar', async() => {
+      const spyShow = sinon.spy(
+        Store.StatusActions,
+        'showIndeterminateProgressBar'
+      );
+      const spyDone = sinon.spy(
+        Store.StatusActions,
+        'done'
+      );
+
+      sinon.replace(
+        Store,
+        '_connectWithConnectionString',
+        sinon.fake.throws(new Error('test error'))
       );
 
       await Store.onConnectClicked();

--- a/test/renderer/stores/index.spec.js
+++ b/test/renderer/stores/index.spec.js
@@ -1840,7 +1840,7 @@ describe('Store', () => {
       expect(spyDone.calledOnce).to.equal(true);
     });
 
-    it('shows and hides the progress bar', async() => {
+    it('shows and hides the progress bar when theres an error connecting', async() => {
       const spyShow = sinon.spy(
         Store.StatusActions,
         'showIndeterminateProgressBar'


### PR DESCRIPTION
COMPASS-4202

Bug was caused by starting the `showIndeterminateProgressBar` but never hiding it on validation error. The validation error which disables the `connect` button is debounced and async also so it doesn't always prevent the user from trying to connect to an invalid connection string. This pr now fixes the handling of those invalid connection attempts.

Here's what the previous infinite loading looks like now (testing new mp4 functionality in vscode 🤔 ):

https://user-images.githubusercontent.com/1791149/104356174-ea5e9380-550b-11eb-9239-80bb287a35f4.mp4


