### PR TITLE
fix: allow port input to be empty COMPASS-4607

### DIFF
--- a/src/components/form/port-input.jsx
+++ b/src/components/form/port-input.jsx
@@ -15,7 +15,7 @@ class PortInput extends React.PureComponent {
    * @param {Object} evt - evt.
    */
   onPortChanged(evt) {
-    Actions.onPortChanged(+evt.target.value);
+    Actions.onPortChanged(evt.target.value);
   }
 
   render() {

--- a/src/components/form/port-input.jsx
+++ b/src/components/form/port-input.jsx
@@ -18,19 +18,6 @@ class PortInput extends React.PureComponent {
     Actions.onPortChanged(+evt.target.value);
   }
 
-  /**
-   * Gets port.
-   *
-   * @returns {Number} port.
-   */
-  getPort() {
-    if (this.props.isPortChanged === false) {
-      return 27017;
-    }
-
-    return +this.props.port;
-  }
-
   render() {
     return (
       <FormInput
@@ -38,7 +25,7 @@ class PortInput extends React.PureComponent {
         name="port"
         placeholder="27017"
         changeHandler={this.onPortChanged.bind(this)}
-        value={this.getPort()}
+        value={this.props.port}
         type="number"
         otherInputAttributes={{min: 1, max: 65536}} />
     );

--- a/src/components/form/port-input.jsx
+++ b/src/components/form/port-input.jsx
@@ -7,7 +7,14 @@ import FormInput from './form-input';
 class PortInput extends React.PureComponent {
   static displayName = 'PortInput';
 
-  static propTypes = { port: PropTypes.number };
+  static propTypes = {
+    port: PropTypes.number // initial port
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { port: props.port };
+  }
 
   /**
    * Changes port.
@@ -15,19 +22,24 @@ class PortInput extends React.PureComponent {
    * @param {Object} evt - evt.
    */
   onPortChanged(evt) {
-    Actions.onPortChanged(evt.target.value);
+    this.setState({ port: evt.target.value });
+    Actions.onPortChanged(evt.target.value ? +evt.target.value : 27017);
   }
 
   render() {
+    if (!this.state) {
+      return;
+    }
+
     return (
       <FormInput
         label="Port"
         name="port"
         placeholder="27017"
         changeHandler={this.onPortChanged.bind(this)}
-        value={this.props.port}
+        value={this.state.port}
         type="number"
-        otherInputAttributes={{min: 1, max: 65536}} />
+        otherInputAttributes={{ min: 1, max: 65536 }} />
     );
   }
 }

--- a/src/components/form/port-input.jsx
+++ b/src/components/form/port-input.jsx
@@ -7,7 +7,7 @@ import FormInput from './form-input';
 class PortInput extends React.PureComponent {
   static displayName = 'PortInput';
 
-  static propTypes = { port: PropTypes.number, isPortChanged: PropTypes.bool };
+  static propTypes = { port: PropTypes.number };
 
   /**
    * Changes port.


### PR DESCRIPTION
Allow port input to be empty

https://user-images.githubusercontent.com/334881/106772111-fab3eb00-663f-11eb-9808-f2555014d0d8.mp4

