### PR TITLE
chore: Rename currentConnection to connectionModel

### DIFF
--- a/src/components/connect.jsx
+++ b/src/components/connect.jsx
@@ -22,8 +22,8 @@ class Connect extends React.Component {
 
   static propTypes = {
     connectingStatusText: PropTypes.string,
+    connectionModel: PropTypes.object,
     connections: PropTypes.object,
-    currentConnection: PropTypes.object,
     currentConnectionAttempt: PropTypes.object,
     isConnected: PropTypes.bool,
     viewType: PropTypes.string,
@@ -109,23 +109,23 @@ class Connect extends React.Component {
   renderHeader() {
     let name = 'New Connection';
 
-    if (this.props.currentConnection.isFavorite) {
+    if (this.props.connectionModel.isFavorite) {
       name =
-        this.props.currentConnection.name.length > 40
-          ? `${this.props.currentConnection.name.substring(0, 40)}...`
-          : this.props.currentConnection.name;
+        this.props.connectionModel.name.length > 40
+          ? `${this.props.connectionModel.name.substring(0, 40)}...`
+          : this.props.connectionModel.name;
     }
 
     return (
       <header>
         <h2>{name}</h2>
         <IsFavoritePill
-          currentConnection={this.props.currentConnection}
+          connectionModel={this.props.connectionModel}
           isModalVisible={this.props.isModalVisible}
           isMessageVisible={this.props.isMessageVisible}
           savedMessage={this.props.savedMessage}
-          color={this.props.currentConnection.color}
-          isFavorite={this.props.currentConnection.isFavorite}
+          color={this.props.connectionModel.color}
+          isFavorite={this.props.connectionModel.isFavorite}
         />
       </header>
     );

--- a/src/components/form/authentication.jsx
+++ b/src/components/form/authentication.jsx
@@ -10,18 +10,18 @@ class Authentication extends React.Component {
   static displayName = 'Authentication';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     isValid: PropTypes.bool
   };
 
   constructor(props) {
     super(props);
     this.setupAuthenticationRoles();
-    this.state = { authStrategy: props.currentConnection.authStrategy };
+    this.state = { authStrategy: props.connectionModel.authStrategy };
   }
 
   componentWillReceiveProps(nextProps) {
-    const authStrategy = nextProps.currentConnection.authStrategy;
+    const authStrategy = nextProps.connectionModel.authStrategy;
 
     if (authStrategy !== this.state.authStrategy) {
       this.setState({ authStrategy });
@@ -70,7 +70,7 @@ class Authentication extends React.Component {
           name="authStrategy"
           options={this.selectOptions}
           changeHandler={this.onAuthStrategyChanged.bind(this)}
-          value={this.props.currentConnection.authStrategy}
+          value={this.props.connectionModel.authStrategy}
         />
         {this.renderAuthStrategy()}
       </FormGroup>

--- a/src/components/form/authentication.spec.js
+++ b/src/components/form/authentication.spec.js
@@ -8,7 +8,7 @@ import Authentication from './authentication';
 import styles from '../connect.less';
 
 describe('Authentication [Component]', () => {
-  const connection = { authStrategy: 'MONGODB' };
+  const connectionModel = { authStrategy: 'MONGODB' };
   const appRegistry = new AppRegistry();
   let component;
 
@@ -36,7 +36,7 @@ describe('Authentication [Component]', () => {
 
   beforeEach(() => {
     component = mount(
-      <Authentication currentConnection={connection} isValid />
+      <Authentication connectionModel={connectionModel} isValid />
     );
   });
 

--- a/src/components/form/connection-form.jsx
+++ b/src/components/form/connection-form.jsx
@@ -20,7 +20,7 @@ class ConnectionForm extends React.Component {
   static displayName = 'ConnectionForm';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     currentConnectionAttempt: PropTypes.object,
     isValid: PropTypes.bool.isRequired,
     isHostChanged: PropTypes.bool,
@@ -62,10 +62,10 @@ class ConnectionForm extends React.Component {
    * @returns {React.Component}
    */
   renderPort() {
-    if (!this.props.currentConnection.isSrvRecord) {
+    if (!this.props.connectionModel.isSrvRecord) {
       return (
         <PortInput
-          port={this.props.currentConnection.port}
+          port={this.props.connectionModel.port}
           isPortChanged={this.props.isPortChanged} />
       );
     }
@@ -119,16 +119,16 @@ class ConnectionForm extends React.Component {
             <div className={classnames(styles['tabs-view-content-form'])}>
               <FormGroup separator>
                 <HostInput
-                  hostname={this.props.currentConnection.hostname}
+                  hostname={this.props.connectionModel.hostname}
                   isHostChanged={this.props.isHostChanged} />
                 {this.renderPort()}
                 <SRVInput
                   currentConnectionAttempt={this.props.currentConnectionAttempt}
-                  isSrvRecord={this.props.currentConnection.isSrvRecord}
+                  isSrvRecord={this.props.connectionModel.isSrvRecord}
                 />
               </FormGroup>
               <Authentication
-                currentConnection={this.props.currentConnection}
+                connectionModel={this.props.connectionModel}
                 isValid={this.props.isValid} />
             </div>
           </div>
@@ -143,10 +143,10 @@ class ConnectionForm extends React.Component {
             <div className={classnames(styles['tabs-view-content-form'])}>
               <FormGroup id="read-preference" separator>
                 <ReplicaSetInput
-                  sshTunnel={this.props.currentConnection.sshTunnel}
-                  replicaSet={this.props.currentConnection.replicaSet} />
+                  sshTunnel={this.props.connectionModel.sshTunnel}
+                  replicaSet={this.props.connectionModel.replicaSet} />
                 <ReadPreferenceSelect
-                  readPreference={this.props.currentConnection.readPreference} />
+                  readPreference={this.props.connectionModel.readPreference} />
               </FormGroup>
               <SSLMethod {...this.props} />
               <SSHTunnel {...this.props} />

--- a/src/components/form/connection-form.spec.js
+++ b/src/components/form/connection-form.spec.js
@@ -43,7 +43,7 @@ describe('ConnectionForm [Component]', () => {
       beforeEach(() => {
         component = mount(
           <ConnectionForm
-            currentConnection={connection}
+            connectionModel={connection}
             isHostChanged={isHostChanged}
             isPortChanged={isPortChanged}
             isValid />
@@ -81,7 +81,7 @@ describe('ConnectionForm [Component]', () => {
         const authentication = component.find('Authentication');
 
         expect(authentication).to.be.present();
-        expect(authentication.prop('currentConnection')).to.deep.equal(connection);
+        expect(authentication.prop('connectionModel')).to.deep.equal(connection);
         expect(authentication.prop('isValid')).to.equal(true);
       });
 
@@ -113,7 +113,7 @@ describe('ConnectionForm [Component]', () => {
         const component = mount(
           <ConnectionForm
             currentConnectionAttempt
-            currentConnection={{
+            connectionModel={{
               authStrategy: 'MONGODB',
               isSrvRecord: false,
               readPreference: 'primaryPreferred',
@@ -160,7 +160,7 @@ describe('ConnectionForm [Component]', () => {
       beforeEach(() => {
         component = mount(
           <ConnectionForm
-            currentConnection={connection}
+            connectionModel={connection}
             isHostChanged={isHostChanged}
             isPortChanged={isPortChanged}
             isValid />
@@ -231,7 +231,7 @@ describe('ConnectionForm [Component]', () => {
 
     beforeEach(() => {
       component = mount(
-        <ConnectionForm currentConnection={connection} isValid />
+        <ConnectionForm connectionModel={connection} isValid />
       );
       component.setState({ activeTab: 1 });
     });

--- a/src/components/form/connection-string.jsx
+++ b/src/components/form/connection-string.jsx
@@ -12,7 +12,7 @@ class ConnectionString extends React.Component {
   static displayName = 'ConnectionString';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     customUrl: PropTypes.string,
     isValid: PropTypes.bool,
     isConnected: PropTypes.bool,
@@ -39,7 +39,7 @@ class ConnectionString extends React.Component {
             />
           </FormGroup>
           <FormActions
-            currentConnection={this.props.currentConnection}
+            connectionModel={this.props.connectionModel}
             isValid={this.props.isValid}
             isConnected={this.props.isConnected}
             currentConnectionAttempt={this.props.currentConnectionAttempt}

--- a/src/components/form/connection-string.spec.js
+++ b/src/components/form/connection-string.spec.js
@@ -18,7 +18,7 @@ describe('ConnectionString [Component]', () => {
   beforeEach(() => {
     component = shallow(
       <ConnectionString
-        currentConnection={connection}
+        connectionModel={connection}
         customUrl={customUrl}
         isValid />
     );

--- a/src/components/form/favorite-modal.jsx
+++ b/src/components/form/favorite-modal.jsx
@@ -16,7 +16,7 @@ class FavoriteModal extends PureComponent {
   static displayName = 'FavoriteModal';
 
   static propTypes = {
-    currentConnection: PropTypes.object,
+    connectionModel: PropTypes.object,
     deleteFavorite: PropTypes.func,
     saveFavorite: PropTypes.func,
     closeFavoriteModal: PropTypes.func
@@ -25,8 +25,8 @@ class FavoriteModal extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      name: props.currentConnection.name,
-      color: props.currentConnection.color
+      name: props.connectionModel.name,
+      color: props.connectionModel.color
     };
   }
 
@@ -34,7 +34,7 @@ class FavoriteModal extends PureComponent {
    * Deletes a favorite.
    */
   onDeleteFavoriteClicked() {
-    this.props.deleteFavorite(this.props.currentConnection);
+    this.props.deleteFavorite(this.props.connectionModel);
   }
 
   /**
@@ -86,7 +86,7 @@ class FavoriteModal extends PureComponent {
    * @returns {React.Component}
    */
   renderDeleteFavorite() {
-    if (this.props.currentConnection.isFavorite) {
+    if (this.props.connectionModel.isFavorite) {
       return (
         <div className={classnames(styles['delete-favorite'])}>
           <TextButton
@@ -105,7 +105,7 @@ class FavoriteModal extends PureComponent {
    * @returns {String}
    */
   renderModalTitle() {
-    return this.props.currentConnection.isFavorite
+    return this.props.connectionModel.isFavorite
       ? 'Edit favorite'
       : 'Save connection to favorites';
   }

--- a/src/components/form/favorite-modal.spec.js
+++ b/src/components/form/favorite-modal.spec.js
@@ -20,7 +20,7 @@ describe('FavoriteModal [Component]', () => {
     beforeEach(() => {
       component = mount(
         <FavoriteModal
-          currentConnection={connection}
+          connectionModel={connection}
           deleteFavorite={deleteFavorite}
           saveFavorite={saveFavorite}
           closeFavoriteModal={closeFavoriteModal} />
@@ -56,7 +56,7 @@ describe('FavoriteModal [Component]', () => {
     beforeEach(() => {
       component = mount(
         <FavoriteModal
-          currentConnection={connection}
+          connectionModel={connection}
           deleteFavorite={deleteFavorite}
           saveFavorite={saveFavorite}
           closeFavoriteModal={closeFavoriteModal} />
@@ -92,7 +92,7 @@ describe('FavoriteModal [Component]', () => {
     beforeEach(() => {
       component = mount(
         <FavoriteModal
-          currentConnection={connection}
+          connectionModel={connection}
           deleteFavorite={deleteFavorite}
           saveFavorite={saveFavorite}
           closeFavoriteModal={closeFavoriteModal} />

--- a/src/components/form/form-actions.jsx
+++ b/src/components/form/form-actions.jsx
@@ -13,7 +13,7 @@ class FormActions extends React.Component {
   static displayName = 'FormActions';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     currentConnectionAttempt: PropTypes.object,
     isValid: PropTypes.bool,
     isConnected: PropTypes.bool,
@@ -126,7 +126,7 @@ class FormActions extends React.Component {
         <a id="discardChanges" onClick={this.onChangesDiscarded}>
           [discard]
         </a>
-        {this.props.currentConnection.isFavorite ? (
+        {this.props.connectionModel.isFavorite ? (
           <a id="saveChanges" onClick={this.onSaveFavoriteClicked}>
             [save changes]
           </a>
@@ -270,8 +270,8 @@ class FormActions extends React.Component {
    * @returns {React.Component}
    */
   renderMessage() {
-    const connection = this.props.currentConnection;
-    const server = `${connection.hostname}:${connection.port}`;
+    const connectionModel = this.props.connectionModel;
+    const server = `${connectionModel.hostname}:${connectionModel.port}`;
     let message = `Connected to ${server}`;
     let colorStyle = styles['connection-message-container-success'];
     let hasMessage = false;

--- a/src/components/form/form-actions.spec.js
+++ b/src/components/form/form-actions.spec.js
@@ -20,7 +20,7 @@ describe('FormActions [Component]', () => {
           beforeEach(() => {
             component = mount(
               <FormActions
-                currentConnection={connection}
+                connectionModel={connection}
                 isConnected={isConnected}
                 viewType={viewType}
                 isURIEditable={isURIEditable}
@@ -77,7 +77,7 @@ describe('FormActions [Component]', () => {
             beforeEach(() => {
               component = mount(
                 <FormActions
-                  currentConnection={connection}
+                  connectionModel={connection}
                   isConnected={isConnected}
                   viewType={viewType}
                   isURIEditable={isURIEditable}
@@ -117,7 +117,7 @@ describe('FormActions [Component]', () => {
             beforeEach(() => {
               component = mount(
                 <FormActions
-                  currentConnection={connection}
+                  connectionModel={connection}
                   isConnected={isConnected}
                   viewType={viewType}
                   isURIEditable={isURIEditable}
@@ -156,7 +156,7 @@ describe('FormActions [Component]', () => {
           beforeEach(() => {
             component = mount(
               <FormActions
-                currentConnection={connection}
+                connectionModel={connection}
                 isConnected={isConnected}
                 viewType={viewType}
                 isURIEditable={isURIEditable}
@@ -182,7 +182,7 @@ describe('FormActions [Component]', () => {
           beforeEach(() => {
             component = mount(
               <FormActions
-                currentConnection={{ name: 'myconnection' }}
+                connectionModel={{ name: 'myconnection' }}
                 currentConnectionAttempt
                 isConnected={false}
                 viewType="connectionString"
@@ -219,7 +219,7 @@ describe('FormActions [Component]', () => {
         beforeEach(() => {
           component = mount(
             <FormActions
-              currentConnection={connection}
+              connectionModel={connection}
               isConnected={isConnected}
               viewType={viewType}
               isURIEditable={isURIEditable}
@@ -268,7 +268,7 @@ describe('FormActions [Component]', () => {
       beforeEach(() => {
         component = mount(
           <FormActions
-            currentConnection={connection}
+            connectionModel={connection}
             isConnected={isConnected}
             isValid
           />
@@ -300,7 +300,7 @@ describe('FormActions [Component]', () => {
     beforeEach(() => {
       component = mount(
         <FormActions
-          currentConnection={connection}
+          connectionModel={connection}
           isValid={isValid}
           errorMessage={errorMessage}
         />
@@ -329,7 +329,7 @@ describe('FormActions [Component]', () => {
       beforeEach(() => {
         component = mount(
           <FormActions
-            currentConnection={connection}
+            connectionModel={connection}
             isValid={isValid}
             viewType={viewType}
             syntaxErrorMessage={syntaxErrorMessage}
@@ -366,7 +366,7 @@ describe('FormActions [Component]', () => {
       beforeEach(() => {
         component = mount(
           <FormActions
-            currentConnection={connection}
+            connectionModel={connection}
             isValid={isValid}
             viewType={viewType}
             syntaxErrorMessage={syntaxErrorMessage}
@@ -396,7 +396,7 @@ describe('FormActions [Component]', () => {
     beforeEach(() => {
       component = mount(
         <FormActions
-          currentConnection={connection}
+          connectionModel={connection}
           isValid={isValid}
           errorMessage={errorMessage}
           syntaxErrorMessage={syntaxErrorMessage}
@@ -435,7 +435,7 @@ describe('FormActions [Component]', () => {
         beforeEach(() => {
           component = mount(
             <FormActions
-              currentConnection={connection}
+              connectionModel={connection}
               isConnected={isConnected}
               viewType={viewType}
               errorMessage={errorMessage}
@@ -477,7 +477,7 @@ describe('FormActions [Component]', () => {
         beforeEach(() => {
           component = mount(
             <FormActions
-              currentConnection={connection}
+              connectionModel={connection}
               isConnected={isConnected}
               viewType={viewType}
               errorMessage={errorMessage}
@@ -513,7 +513,7 @@ describe('FormActions [Component]', () => {
         beforeEach(() => {
           component = mount(
             <FormActions
-              currentConnection={connection}
+              connectionModel={connection}
               isConnected={isConnected}
               viewType={viewType}
               errorMessage={errorMessage}
@@ -546,7 +546,7 @@ describe('FormActions [Component]', () => {
         beforeEach(() => {
           component = mount(
             <FormActions
-              currentConnection={connection}
+              connectionModel={connection}
               isConnected={isConnected}
               viewType={viewType}
               errorMessage={errorMessage}
@@ -581,7 +581,7 @@ describe('FormActions [Component]', () => {
         beforeEach(() => {
           component = mount(
             <FormActions
-              currentConnection={connection}
+              connectionModel={connection}
               isConnected={isConnected}
               viewType={viewType}
               errorMessage={errorMessage}
@@ -614,7 +614,7 @@ describe('FormActions [Component]', () => {
         beforeEach(() => {
           component = mount(
             <FormActions
-              currentConnection={connection}
+              connectionModel={connection}
               isConnected={isConnected}
               viewType={viewType}
               errorMessage={errorMessage}
@@ -649,7 +649,7 @@ describe('FormActions [Component]', () => {
     beforeEach(() => {
       component = mount(
         <FormActions
-          currentConnection={connection}
+          connectionModel={connection}
           isConnected={isConnected}
           viewType={viewType}
           errorMessage={errorMessage}

--- a/src/components/form/is-favorite-pill.jsx
+++ b/src/components/form/is-favorite-pill.jsx
@@ -15,7 +15,7 @@ class IsFavoritePill extends PureComponent {
   static displayName = 'IsFavoritePill';
 
   static propTypes = {
-    currentConnection: PropTypes.object,
+    connectionModel: PropTypes.object,
     isModalVisible: PropTypes.bool,
     isMessageVisible: PropTypes.bool,
     savedMessage: PropTypes.string,
@@ -71,7 +71,7 @@ class IsFavoritePill extends PureComponent {
     if (this.props.isModalVisible) {
       return (
         <FavoriteModal
-          currentConnection={this.props.currentConnection}
+          connectionModel={this.props.connectionModel}
           deleteFavorite={this.deleteFavorite}
           closeFavoriteModal={this.closeFavoriteModal}
           saveFavorite={this.saveFavorite} />

--- a/src/components/form/is-favorite-pill.spec.js
+++ b/src/components/form/is-favorite-pill.spec.js
@@ -21,7 +21,7 @@ describe('IsFavoritePill [Component]', () => {
     beforeEach(() => {
       component = shallow(
         <IsFavoritePill
-          currentConnection={connection}
+          connectionModel={connection}
           isModalVisible={isModalVisible}
           isMessageVisible={isMessageVisible} />
       );
@@ -53,7 +53,7 @@ describe('IsFavoritePill [Component]', () => {
     beforeEach(() => {
       component = shallow(
         <IsFavoritePill
-          currentConnection={connection}
+          connectionModel={connection}
           isModalVisible={isModalVisible}
           isMessageVisible={isMessageVisible} />
       );

--- a/src/components/form/mongodb-authentication.jsx
+++ b/src/components/form/mongodb-authentication.jsx
@@ -11,7 +11,7 @@ class MongoDBAuthentication extends React.Component {
   static displayName = 'MongoDBAuthentication';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     isValid: PropTypes.bool
   };
 
@@ -57,9 +57,9 @@ class MongoDBAuthentication extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getUsernameError() {
-    const connection = this.props.currentConnection;
+    const connectionModel = this.props.connectionModel;
 
-    if (!this.props.isValid && isEmpty(connection.mongodbUsername)) {
+    if (!this.props.isValid && isEmpty(connectionModel.mongodbUsername)) {
       return true;
     }
   }
@@ -70,9 +70,9 @@ class MongoDBAuthentication extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getPasswordError() {
-    const connection = this.props.currentConnection;
+    const connectionModel = this.props.connectionModel;
 
-    if (!this.props.isValid && isEmpty(connection.mongodbPassword)) {
+    if (!this.props.isValid && isEmpty(connectionModel.mongodbPassword)) {
       return true;
     }
   }
@@ -85,7 +85,7 @@ class MongoDBAuthentication extends React.Component {
           name="username"
           error={this.getUsernameError()}
           changeHandler={this.onUsernameChanged.bind(this)}
-          value={this.props.currentConnection.mongodbUsername || ''}
+          value={this.props.connectionModel.mongodbUsername || ''}
         />
         <FormInput
           label="Password"
@@ -93,14 +93,14 @@ class MongoDBAuthentication extends React.Component {
           type="password"
           error={this.getPasswordError()}
           changeHandler={this.onPasswordChanged.bind(this)}
-          value={this.props.currentConnection.mongodbPassword || ''}
+          value={this.props.connectionModel.mongodbPassword || ''}
         />
         <FormInput
           label="Authentication Database"
           placeholder="admin"
           name="auth-source"
           changeHandler={this.onAuthSourceChanged.bind(this)}
-          value={this.props.currentConnection.mongodbDatabaseName || ''}
+          value={this.props.connectionModel.mongodbDatabaseName || ''}
           linkHandler={this.onSourceHelp.bind(this)}
         />
       </FormGroup>

--- a/src/components/form/mongodb-authentication.spec.js
+++ b/src/components/form/mongodb-authentication.spec.js
@@ -16,7 +16,7 @@ describe('MongoDBAuthentication [Component]', () => {
 
     beforeEach(() => {
       component = mount(
-        <MongoDBAuthentication currentConnection={connection} isValid />
+        <MongoDBAuthentication connectionModel={connection} isValid />
       );
     });
 
@@ -52,7 +52,7 @@ describe('MongoDBAuthentication [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <MongoDBAuthentication currentConnection={connection} />
+          <MongoDBAuthentication connectionModel={connection} />
         );
       });
 
@@ -79,7 +79,7 @@ describe('MongoDBAuthentication [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <MongoDBAuthentication currentConnection={connection} />
+          <MongoDBAuthentication connectionModel={connection} />
         );
       });
 
@@ -106,7 +106,7 @@ describe('MongoDBAuthentication [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <MongoDBAuthentication currentConnection={connection} />
+          <MongoDBAuthentication connectionModel={connection} />
         );
       });
 
@@ -133,7 +133,7 @@ describe('MongoDBAuthentication [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <MongoDBAuthentication currentConnection={connection} />
+          <MongoDBAuthentication connectionModel={connection} />
         );
       });
 
@@ -160,7 +160,7 @@ describe('MongoDBAuthentication [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <MongoDBAuthentication currentConnection={connection} />
+          <MongoDBAuthentication connectionModel={connection} />
         );
       });
 
@@ -187,7 +187,7 @@ describe('MongoDBAuthentication [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <MongoDBAuthentication currentConnection={connection} />
+          <MongoDBAuthentication connectionModel={connection} />
         );
       });
 

--- a/src/components/form/scram-sha-256.jsx
+++ b/src/components/form/scram-sha-256.jsx
@@ -13,7 +13,7 @@ class ScramSha256 extends React.Component {
   static displayName = 'ScramSha256';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     isValid: PropTypes.bool
   };
 
@@ -59,9 +59,9 @@ class ScramSha256 extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getUsernameError() {
-    const connection = this.props.currentConnection;
+    const connectionModel = this.props.connectionModel;
 
-    if (!this.props.isValid && isEmpty(connection.mongodbUsername)) {
+    if (!this.props.isValid && isEmpty(connectionModel.mongodbUsername)) {
       return true;
     }
   }
@@ -72,7 +72,7 @@ class ScramSha256 extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getPasswordError() {
-    const connection = this.props.currentConnection;
+    const connection = this.props.connectionModel;
 
     if (!this.props.isValid && isEmpty(connection.mongodbPassword)) {
       return true;
@@ -87,7 +87,7 @@ class ScramSha256 extends React.Component {
           name="username"
           error={this.getUsernameError()}
           changeHandler={this.onUsernameChanged.bind(this)}
-          value={this.props.currentConnection.mongodbUsername || ''}
+          value={this.props.connectionModel.mongodbUsername || ''}
         />
         <FormInput
           label="Password"
@@ -95,14 +95,14 @@ class ScramSha256 extends React.Component {
           type="password"
           error={this.getPasswordError()}
           changeHandler={this.onPasswordChanged.bind(this)}
-          value={this.props.currentConnection.mongodbPassword || ''}
+          value={this.props.connectionModel.mongodbPassword || ''}
         />
         <FormInput
           label="Authentication Database"
           placeholder="admin"
           name="authSource"
           changeHandler={this.onAuthSourceChanged.bind(this)}
-          value={this.props.currentConnection.mongodbDatabaseName || ''}
+          value={this.props.connectionModel.mongodbDatabaseName || ''}
           linkHandler={this.onSourceHelp.bind(this)}
         />
       </div>

--- a/src/components/form/ssh-tunnel-identity-file-validation.jsx
+++ b/src/components/form/ssh-tunnel-identity-file-validation.jsx
@@ -12,7 +12,7 @@ class SSHTunnelIdentityFileValidation extends React.Component {
   static displayName = 'SSHTunnelIdentityFileValidation';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     isValid: PropTypes.bool
   };
 
@@ -74,7 +74,7 @@ class SSHTunnelIdentityFileValidation extends React.Component {
    * @returns {Number} sshTunnelPort.
    */
   getPort() {
-    return this.props.currentConnection.sshTunnelPort;
+    return this.props.connectionModel.sshTunnelPort;
   }
 
   /**
@@ -83,7 +83,7 @@ class SSHTunnelIdentityFileValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getHostnameError() {
-    if (this._isInvalid(this.props.currentConnection.sshTunnelHostname)) {
+    if (this._isInvalid(this.props.connectionModel.sshTunnelHostname)) {
       return true;
     }
   }
@@ -94,7 +94,7 @@ class SSHTunnelIdentityFileValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getPortError() {
-    if (this._isInvalid(this.props.currentConnection.sshTunnelPort)) {
+    if (this._isInvalid(this.props.connectionModel.sshTunnelPort)) {
       return true;
     }
   }
@@ -105,7 +105,7 @@ class SSHTunnelIdentityFileValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getUsernameError() {
-    if (this._isInvalid(this.props.currentConnection.sshTunnelUsername)) {
+    if (this._isInvalid(this.props.connectionModel.sshTunnelUsername)) {
       return true;
     }
   }
@@ -116,7 +116,7 @@ class SSHTunnelIdentityFileValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getFileError() {
-    if (this._isInvalid(this.props.currentConnection.sshTunnelIdentityFile)) {
+    if (this._isInvalid(this.props.connectionModel.sshTunnelIdentityFile)) {
       return true;
     }
   }
@@ -140,7 +140,7 @@ class SSHTunnelIdentityFileValidation extends React.Component {
           name="sshTunnelHostname"
           error={this.getHostnameError()}
           changeHandler={this.onSSHTunnelHostnameChanged.bind(this)}
-          value={this.props.currentConnection.sshTunnelHostname || ''}
+          value={this.props.connectionModel.sshTunnelHostname || ''}
           linkHandler={this.onSourceHelp.bind(this)}
         />
         <FormInput
@@ -157,21 +157,21 @@ class SSHTunnelIdentityFileValidation extends React.Component {
           name="sshTunnelUsername"
           error={this.getUsernameError()}
           changeHandler={this.onSSHTunnelUsernameChanged.bind(this)}
-          value={this.props.currentConnection.sshTunnelUsername || ''}
+          value={this.props.connectionModel.sshTunnelUsername || ''}
         />
         <FormFileInput
           label="SSH Identity File"
           id="sshTunnelIdentityFile"
           error={this.getFileError()}
           changeHandler={this.onSSHTunnelIdentityFileChanged.bind(this)}
-          values={this.props.currentConnection.sshTunnelIdentityFile}
+          values={this.props.connectionModel.sshTunnelIdentityFile}
         />
         <FormInput
           label="SSH Passphrase"
           name="sshTunnelPassphrase"
           type="password"
           changeHandler={this.onSSHTunnelPassphraseChanged.bind(this)}
-          value={this.props.currentConnection.sshTunnelPassphrase || ''}
+          value={this.props.connectionModel.sshTunnelPassphrase || ''}
         />
       </FormGroup>
     );

--- a/src/components/form/ssh-tunnel-password-validation.jsx
+++ b/src/components/form/ssh-tunnel-password-validation.jsx
@@ -11,7 +11,7 @@ class SSHTunnelPasswordValidation extends React.Component {
   static displayName = 'SSHTunnelPasswordValidation';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     isValid: PropTypes.bool
   };
 
@@ -64,7 +64,7 @@ class SSHTunnelPasswordValidation extends React.Component {
    * @returns {Number} sshTunnelPort.
    */
   getPort() {
-    return this.props.currentConnection.sshTunnelPort;
+    return this.props.connectionModel.sshTunnelPort;
   }
 
   /**
@@ -73,7 +73,7 @@ class SSHTunnelPasswordValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getHostnameError() {
-    if (this._isInvalid(this.props.currentConnection.sshTunnelHostname)) {
+    if (this._isInvalid(this.props.connectionModel.sshTunnelHostname)) {
       return true;
     }
   }
@@ -84,7 +84,7 @@ class SSHTunnelPasswordValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getPortError() {
-    if (this._isInvalid(this.props.currentConnection.sshTunnelPort)) {
+    if (this._isInvalid(this.props.connectionModel.sshTunnelPort)) {
       return true;
     }
   }
@@ -95,7 +95,7 @@ class SSHTunnelPasswordValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getUsernameError() {
-    if (this._isInvalid(this.props.currentConnection.sshTunnelUsername)) {
+    if (this._isInvalid(this.props.connectionModel.sshTunnelUsername)) {
       return true;
     }
   }
@@ -106,7 +106,7 @@ class SSHTunnelPasswordValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getPasswordError() {
-    if (this._isInvalid(this.props.currentConnection.sshTunnelPassword)) {
+    if (this._isInvalid(this.props.connectionModel.sshTunnelPassword)) {
       return true;
     }
   }
@@ -130,7 +130,7 @@ class SSHTunnelPasswordValidation extends React.Component {
           name="sshTunnelHostname"
           error={this.getHostnameError()}
           changeHandler={this.onSSHTunnelHostnameChanged.bind(this)}
-          value={this.props.currentConnection.sshTunnelHostname || ''}
+          value={this.props.connectionModel.sshTunnelHostname || ''}
           linkHandler={this.onHostnameHelp.bind(this)}
         />
         <FormInput
@@ -145,7 +145,7 @@ class SSHTunnelPasswordValidation extends React.Component {
           name="sshTunnelUsername"
           error={this.getUsernameError()}
           changeHandler={this.onSSHTunnelUsernameChanged.bind(this)}
-          value={this.props.currentConnection.sshTunnelUsername || ''}
+          value={this.props.connectionModel.sshTunnelUsername || ''}
         />
         <FormInput
           label="SSH Password"
@@ -153,7 +153,7 @@ class SSHTunnelPasswordValidation extends React.Component {
           type="password"
           error={this.getPasswordError()}
           changeHandler={this.onSSHTunnelPasswordChanged.bind(this)}
-          value={this.props.currentConnection.sshTunnelPassword || ''}
+          value={this.props.connectionModel.sshTunnelPassword || ''}
         />
       </FormGroup>
     );

--- a/src/components/form/ssh-tunnel.jsx
+++ b/src/components/form/ssh-tunnel.jsx
@@ -9,16 +9,16 @@ import FormItemSelect from './form-item-select';
 class SSHTunnel extends React.Component {
   static displayName = 'SSHTunnel';
 
-  static propTypes = { currentConnection: PropTypes.object.isRequired };
+  static propTypes = { connectionModel: PropTypes.object.isRequired };
 
   constructor(props) {
     super(props);
     this.setupSSHTunnelRoles();
-    this.state = { sshTunnel: props.currentConnection.sshTunnel };
+    this.state = { sshTunnel: props.connectionModel.sshTunnel };
   }
 
   componentWillReceiveProps(nextProps) {
-    const sshMethod = nextProps.currentConnection.sshTunnel;
+    const sshMethod = nextProps.connectionModel.sshTunnel;
 
     if (sshMethod !== this.state.sshTunnel) {
       this.setState({ sshTunnel: sshMethod });
@@ -67,7 +67,7 @@ class SSHTunnel extends React.Component {
           name="sshTunnel"
           options={this.selectOptions}
           changeHandler={this.onSSHTunnelChanged.bind(this)}
-          value={this.props.currentConnection.sshTunnel}
+          value={this.props.connectionModel.sshTunnel}
         />
         {this.renderSSHTunnel()}
       </FormGroup>

--- a/src/components/form/ssh-tunnel.spec.js
+++ b/src/components/form/ssh-tunnel.spec.js
@@ -36,7 +36,7 @@ describe('SSHTunnel [Component]', () => {
 
   beforeEach(() => {
     component = mount(
-      <SSHTunnel currentConnection={connection} isValid />
+      <SSHTunnel connectionModel={connection} isValid />
     );
   });
 

--- a/src/components/form/ssl-method.jsx
+++ b/src/components/form/ssl-method.jsx
@@ -9,16 +9,16 @@ import FormItemSelect from './form-item-select';
 class SSLMethod extends React.Component {
   static displayName = 'SSLMethod';
 
-  static propTypes = { currentConnection: PropTypes.object.isRequired };
+  static propTypes = { connectionModel: PropTypes.object.isRequired };
 
   constructor(props) {
     super(props);
     this.setupSSLRoles();
-    this.state = { sslMethod: props.currentConnection.sslMethod };
+    this.state = { sslMethod: props.connectionModel.sslMethod };
   }
 
   componentWillReceiveProps(nextProps) {
-    const sslMethod = nextProps.currentConnection.sslMethod;
+    const sslMethod = nextProps.connectionModel.sslMethod;
 
     if (sslMethod !== this.state.sslMethod) {
       this.setState({ sslMethod: sslMethod });
@@ -67,7 +67,7 @@ class SSLMethod extends React.Component {
           name="sslMethod"
           options={this.selectOptions}
           changeHandler={this.onSSLMethodChanged.bind(this)}
-          value={this.props.currentConnection.sslMethod}
+          value={this.props.connectionModel.sslMethod}
         />
         {this.renderSSLMethod()}
       </FormGroup>

--- a/src/components/form/ssl-method.spec.js
+++ b/src/components/form/ssl-method.spec.js
@@ -36,7 +36,7 @@ describe('SSLMethod [Component]', () => {
 
   beforeEach(() => {
     component = mount(
-      <SSLMethod currentConnection={connection} isValid />
+      <SSLMethod connectionModel={connection} isValid />
     );
   });
 

--- a/src/components/form/ssl-server-client-validation.jsx
+++ b/src/components/form/ssl-server-client-validation.jsx
@@ -14,7 +14,7 @@ class SSLServerClientValidation extends React.Component {
   static displayName = 'SSLServerClientValidation';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     isValid: PropTypes.bool
   };
 
@@ -69,7 +69,7 @@ class SSLServerClientValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getCertAuthError() {
-    if (this._isInvalid(this.props.currentConnection.sslCA)) {
+    if (this._isInvalid(this.props.connectionModel.sslCA)) {
       return true;
     }
   }
@@ -80,7 +80,7 @@ class SSLServerClientValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getClientCertError() {
-    if (this._isInvalid(this.props.currentConnection.sslCert)) {
+    if (this._isInvalid(this.props.connectionModel.sslCert)) {
       return true;
     }
   }
@@ -91,7 +91,7 @@ class SSLServerClientValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getClientKeyError() {
-    if (this._isInvalid(this.props.currentConnection.sslKey)) {
+    if (this._isInvalid(this.props.connectionModel.sslKey)) {
       return true;
     }
   }
@@ -118,7 +118,7 @@ class SSLServerClientValidation extends React.Component {
           id="sslCA"
           error={this.getCertAuthError()}
           changeHandler={this.onCertificateAuthorityChanged.bind(this)}
-          values={this.props.currentConnection.sslCA}
+          values={this.props.connectionModel.sslCA}
           link="https://docs.mongodb.com/manual/tutorial/configure-ssl/#certificate-authorities"
           multi
         />
@@ -127,7 +127,7 @@ class SSLServerClientValidation extends React.Component {
           id="sslCert"
           error={this.getClientCertError()}
           changeHandler={this.onClientCertificateChanged.bind(this)}
-          values={this.props.currentConnection.sslCert}
+          values={this.props.connectionModel.sslCert}
           link="https://docs.mongodb.com/manual/tutorial/configure-ssl/#pem-file"
         />
         <FormFileInput
@@ -135,7 +135,7 @@ class SSLServerClientValidation extends React.Component {
           id="sslKey"
           error={this.getClientKeyError()}
           changeHandler={this.onClientPrivateKeyChanged.bind(this)}
-          values={this.props.currentConnection.sslKey}
+          values={this.props.connectionModel.sslKey}
           link="https://docs.mongodb.com/manual/tutorial/configure-ssl/#pem-file"
         />
         <FormInput
@@ -143,7 +143,7 @@ class SSLServerClientValidation extends React.Component {
           name="sslPass"
           type="password"
           changeHandler={this.onClientKeyPasswordChanged.bind(this)}
-          value={this.props.currentConnection.sslPass || ''}
+          value={this.props.connectionModel.sslPass || ''}
           linkHandler={this.onPasswordHelp.bind(this)}
         />
       </div>

--- a/src/components/form/ssl-server-validation.jsx
+++ b/src/components/form/ssl-server-validation.jsx
@@ -12,7 +12,7 @@ class SSLServerValidation extends React.Component {
   static displayName = 'SSLServerValidation';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     isValid: PropTypes.bool
   };
 
@@ -31,7 +31,7 @@ class SSLServerValidation extends React.Component {
    * @returns {String} In case of error returns an error message.
    */
   getError() {
-    const connection = this.props.currentConnection;
+    const connection = this.props.connectionModel;
 
     if (!this.props.isValid && isEmpty(connection.sslCA)) {
       return true;
@@ -46,7 +46,7 @@ class SSLServerValidation extends React.Component {
         <FormFileInput
           label="Certificate Authority"
           changeHandler={this.onSSLCAChanged.bind(this)}
-          values={this.props.currentConnection.sslCA}
+          values={this.props.connectionModel.sslCA}
           error={this.getError()}
           link="https://docs.mongodb.com/manual/tutorial/configure-ssl/#certificate-authorities"
           multi

--- a/src/components/sidebar/favorites.jsx
+++ b/src/components/sidebar/favorites.jsx
@@ -15,7 +15,7 @@ class Favorites extends React.Component {
   static displayName = 'Favorites';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     connections: PropTypes.object.isRequired
   };
 
@@ -76,7 +76,7 @@ class Favorites extends React.Component {
   getClassName(favorite) {
     const classnamesProps = [styles['connect-sidebar-list-item']];
 
-    if (this.props.currentConnection._id === favorite._id) {
+    if (this.props.connectionModel._id === favorite._id) {
       classnamesProps.push(styles['connect-sidebar-list-item-is-active']);
     }
 

--- a/src/components/sidebar/favorites.spec.js
+++ b/src/components/sidebar/favorites.spec.js
@@ -17,7 +17,7 @@ describe('Favorites [Component]', () => {
 
     beforeEach(() => {
       component = mount(
-        <Favorites currentConnection={{}} connections={favorites} />
+        <Favorites connectionModel={{}} connections={favorites} />
       );
     });
 
@@ -74,7 +74,7 @@ describe('Favorites [Component]', () => {
 
     beforeEach(() => {
       component = mount(
-        <Favorites currentConnection={{}} connections={favorites} />
+        <Favorites connectionModel={{}} connections={favorites} />
       );
     });
 

--- a/src/components/sidebar/index.jsx
+++ b/src/components/sidebar/index.jsx
@@ -12,7 +12,7 @@ class Sidebar extends React.Component {
   static displayName = 'Sidebar';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     connections: PropTypes.object.isRequired
   };
 

--- a/src/components/sidebar/new-connection.jsx
+++ b/src/components/sidebar/new-connection.jsx
@@ -10,7 +10,7 @@ class NewConnection extends React.Component {
   static displayName = 'NewConnection';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     connections: PropTypes.object.isRequired
   };
 
@@ -27,7 +27,7 @@ class NewConnection extends React.Component {
    * @returns {String} - A class name
    */
   getClassName() {
-    const currentSaved = this.props.connections[this.props.currentConnection._id];
+    const currentSaved = this.props.connections[this.props.connectionModel._id];
     const classnamesProps = [styles['connect-sidebar-new-connection']];
 
     if (!currentSaved) {

--- a/src/components/sidebar/new-connection.spec.js
+++ b/src/components/sidebar/new-connection.spec.js
@@ -7,7 +7,7 @@ import styles from './sidebar.less';
 
 describe('NewConnection [Component]', () => {
   context('when a connection is new', () => {
-    const currentConnection = {
+    const connectionModel = {
       _id: '47d5a91a-0920-43e7-a4ef-71430023f484',
       isFavorite: false
     };
@@ -27,7 +27,7 @@ describe('NewConnection [Component]', () => {
       component = mount(
         <NewConnection
           connections={connections}
-          currentConnection={currentConnection} />
+          connectionModel={connectionModel} />
       );
     });
 
@@ -63,7 +63,7 @@ describe('NewConnection [Component]', () => {
   });
 
   context('when a connection is favorite', () => {
-    const currentConnection = {
+    const connectionModel = {
       _id: '47d5a91a-0920-43e7-a4ef-71430023f484',
       isFavorite: true
     };
@@ -77,7 +77,7 @@ describe('NewConnection [Component]', () => {
       component = mount(
         <NewConnection
           connections={connections}
-          currentConnection={currentConnection} />
+          connectionModel={connectionModel} />
       );
     });
 
@@ -93,7 +93,7 @@ describe('NewConnection [Component]', () => {
   });
 
   context('when a connection is recent', () => {
-    const currentConnection = {
+    const connectionModel = {
       _id: '47d5a91a-0920-43e7-a4ef-71430023f484',
       isFavorite: false
     };
@@ -107,7 +107,7 @@ describe('NewConnection [Component]', () => {
       component = mount(
         <NewConnection
           connections={connections}
-          currentConnection={currentConnection} />
+          connectionModel={connectionModel} />
       );
     });
 

--- a/src/components/sidebar/recents.jsx
+++ b/src/components/sidebar/recents.jsx
@@ -15,7 +15,7 @@ class Recents extends React.Component {
   static displayName = 'Recents';
 
   static propTypes = {
-    currentConnection: PropTypes.object.isRequired,
+    connectionModel: PropTypes.object.isRequired,
     connections: PropTypes.object.isRequired
   };
 
@@ -67,7 +67,7 @@ class Recents extends React.Component {
   getClassName(recent) {
     const classnamesProps = [styles['connect-sidebar-list-item']];
 
-    if (this.props.currentConnection._id === recent._id) {
+    if (this.props.connectionModel._id === recent._id) {
       classnamesProps.push(styles['connect-sidebar-list-item-is-active']);
     }
 

--- a/src/components/sidebar/recents.spec.js
+++ b/src/components/sidebar/recents.spec.js
@@ -17,7 +17,7 @@ describe('Recents [Component]', () => {
   let component;
 
   beforeEach(() => {
-    component = mount(<Recents currentConnection={{}} connections={recents} />);
+    component = mount(<Recents connectionModel={{}} connections={recents} />);
   });
 
   afterEach(() => {

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -109,7 +109,7 @@ const Store = Reflux.createStore({
     appRegistry.on('clear-current-favorite', () => {
       const ConnectStore = appRegistry.getStore('Connect.Store');
 
-      ConnectStore.state.currentConnection = new Connection();
+      ConnectStore.state.connectionModel = new Connection();
     });
   },
 
@@ -120,7 +120,7 @@ const Store = Reflux.createStore({
    */
   getInitialState() {
     return {
-      currentConnection: new Connection(),
+      connectionModel: new Connection(),
       // Collection that contains the current state of connections
       fetchedConnections: new ConnectionCollection(),
       // Hash for storing unchanged connections for the discard feature
@@ -183,8 +183,8 @@ const Store = Reflux.createStore({
    */
   async validateConnectionString() {
     const customUrl = this.state.customUrl;
-    const currentConnection = this.state.currentConnection;
-    const currentSaved = this.state.connections[currentConnection._id];
+    const connectionModel = this.state.connectionModel;
+    const currentSaved = this.state.connections[connectionModel._id];
 
     this.state.hasUnsavedChanges = !!currentSaved;
 
@@ -219,7 +219,7 @@ const Store = Reflux.createStore({
    * @param {String} authSource - The auth source.
    */
   onAuthSourceChanged(authSource) {
-    this.state.currentConnection.mongodbDatabaseName = authSource;
+    this.state.connectionModel.mongodbDatabaseName = authSource;
     this.trigger(this.state);
   },
 
@@ -230,7 +230,7 @@ const Store = Reflux.createStore({
    */
   onAuthStrategyChanged(method) {
     this._clearAuthFields();
-    this.state.currentConnection.authStrategy = method;
+    this.state.connectionModel.authStrategy = method;
     this.trigger(this.state);
   },
 
@@ -281,8 +281,8 @@ const Store = Reflux.createStore({
    * Resets URL validation.
    */
   onConnectionFormChanged() {
-    const currentConnection = this.state.currentConnection;
-    const currentSaved = this.state.connections[currentConnection._id];
+    const connectionModel = this.state.connectionModel;
+    const currentSaved = this.state.connections[connectionModel._id];
 
     this.setState({
       isValid: true,
@@ -345,14 +345,14 @@ const Store = Reflux.createStore({
    * Discards changes.
    */
   onChangesDiscarded() {
-    const connection = this.state.connections[this.state.currentConnection._id];
+    const connection = this.state.connections[this.state.connectionModel._id];
 
-    this.state.currentConnection.set(connection);
+    this.state.connectionModel.set(connection);
 
     if (this.state.isURIEditable) {
-      this.state.customUrl = this.state.currentConnection.driverUrl;
+      this.state.customUrl = this.state.connectionModel.driverUrl;
     } else {
-      this.state.customUrl = this.state.currentConnection.safeUrl;
+      this.state.customUrl = this.state.connectionModel.safeUrl;
     }
 
     this.state.hasUnsavedChanges = false;
@@ -364,7 +364,7 @@ const Store = Reflux.createStore({
    */
   onHideURIClicked() {
     this.state.isURIEditable = false;
-    this.state.customUrl = this.state.currentConnection.safeUrl;
+    this.state.customUrl = this.state.connectionModel.safeUrl;
     this.trigger(this.state);
   },
 
@@ -375,8 +375,8 @@ const Store = Reflux.createStore({
    * @param {Object} color - The favorite color.
    */
   onCreateFavoriteClicked(name, color) {
-    this.state.currentConnection.color = color;
-    this.state.currentConnection.name = name;
+    this.state.connectionModel.color = color;
+    this.state.connectionModel.name = name;
     this.state.isMessageVisible = true;
     this._saveFavorite();
   },
@@ -408,8 +408,8 @@ const Store = Reflux.createStore({
         this.state.fetchedConnections.remove(toDestroy._id);
         this.state.connections = this._removeFromCollection(connection._id);
 
-        if (connection._id === this.state.currentConnection._id) {
-          this.state.currentConnection = new Connection();
+        if (connection._id === this.state.connectionModel._id) {
+          this.state.connectionModel = new Connection();
         }
 
         this.trigger(this.state);
@@ -470,7 +470,7 @@ const Store = Reflux.createStore({
     this.state.errorMessage = null;
     this.state.syntaxErrorMessage = null;
     this.state.hasUnsavedChanges = false;
-    this._saveConnection(this.state.currentConnection);
+    this._saveConnection(this.state.connectionModel);
 
     this.dataService = undefined;
   },
@@ -496,7 +496,7 @@ const Store = Reflux.createStore({
    */
   onEditURIConfirmed() {
     this.state.isURIEditable = true;
-    this.state.customUrl = this.state.currentConnection.driverUrl;
+    this.state.customUrl = this.state.connectionModel.driverUrl;
     this.state.isEditURIConfirm = false;
     this.trigger(this.state);
   },
@@ -527,7 +527,7 @@ const Store = Reflux.createStore({
    * @param {String} name - The favorite name.
    */
   onFavoriteNameChanged(name) {
-    this.state.currentConnection.name = name;
+    this.state.connectionModel.name = name;
     this.trigger(this.state);
   },
 
@@ -537,8 +537,8 @@ const Store = Reflux.createStore({
    * @param {Connection} connection - The connection to select.
    */
   onConnectionSelected(connection) {
-    this.state.currentConnection.set({ name: 'Local', color: undefined });
-    this.state.currentConnection.set(connection);
+    this.state.connectionModel.set({ name: 'Local', color: undefined });
+    this.state.connectionModel.set(connection);
     this.trigger(this.state);
     this.setState({
       isURIEditable: false,
@@ -549,7 +549,7 @@ const Store = Reflux.createStore({
       syntaxErrorMessage: null,
       isHostChanged: true,
       isPortChanged: true,
-      customUrl: this.state.currentConnection.safeUrl,
+      customUrl: this.state.connectionModel.safeUrl,
       hasUnsavedChanges: false
     });
   },
@@ -561,11 +561,11 @@ const Store = Reflux.createStore({
    * @param {String} hostname - The hostname.
    */
   onHostnameChanged(hostname) {
-    this.state.currentConnection.hostname = hostname.trim();
+    this.state.connectionModel.hostname = hostname.trim();
     this.state.isHostChanged = true;
 
     if (hostname.match(/mongodb\.net/i)) {
-      this.state.currentConnection.sslMethod = 'SYSTEMCA';
+      this.state.connectionModel.sslMethod = 'SYSTEMCA';
     }
 
     this.trigger(this.state);
@@ -577,7 +577,7 @@ const Store = Reflux.createStore({
    * @param {String} password - The password.
    */
   onPasswordChanged(password) {
-    this.state.currentConnection.mongodbPassword = password;
+    this.state.connectionModel.mongodbPassword = password;
     this.trigger(this.state);
   },
 
@@ -587,7 +587,7 @@ const Store = Reflux.createStore({
    * @param {String} port - The port.
    */
   onPortChanged(port) {
-    this.state.currentConnection.port = port;
+    this.state.connectionModel.port = port;
     this.state.isPortChanged = true;
     this.trigger(this.state);
   },
@@ -598,7 +598,7 @@ const Store = Reflux.createStore({
    * @param {String} readPreference - The read preference.
    */
   onReadPreferenceChanged(readPreference) {
-    this.state.currentConnection.readPreference = readPreference;
+    this.state.connectionModel.readPreference = readPreference;
     this.trigger(this.state);
   },
 
@@ -608,7 +608,7 @@ const Store = Reflux.createStore({
    * @param {String} replicaSet - The replica set name.
    */
   onReplicaSetChanged(replicaSet) {
-    this.state.currentConnection.replicaSet = replicaSet.trim();
+    this.state.connectionModel.replicaSet = replicaSet.trim();
     this.trigger(this.state);
   },
 
@@ -618,7 +618,7 @@ const Store = Reflux.createStore({
   onResetConnectionClicked() {
     this.state.viewType = CONNECTION_STRING_VIEW;
     this.state.savedMessage = 'Saved to favorites';
-    this.state.currentConnection = new Connection();
+    this.state.connectionModel = new Connection();
     this.state.isURIEditable = true;
     this.state.isSavedConnection = false;
     this._clearForm();
@@ -631,12 +631,12 @@ const Store = Reflux.createStore({
    * @param {Object} connection - A recent connection.
    */
   onSaveAsFavoriteClicked(connection) {
-    this.state.currentConnection.set(connection);
+    this.state.connectionModel.set(connection);
     this.state.isMessageVisible = true;
-    this.state.currentConnection.isFavorite = true;
-    this.state.currentConnection.name = `${connection.hostname}:${connection.port}`;
+    this.state.connectionModel.isFavorite = true;
+    this.state.connectionModel.name = `${connection.hostname}:${connection.port}`;
     this.state.savedMessage = 'Saved to favorites';
-    this._saveConnection(this.state.currentConnection);
+    this._saveConnection(this.state.connectionModel);
   },
 
   /**
@@ -652,7 +652,7 @@ const Store = Reflux.createStore({
    * @param {Array} files - The files.
    */
   onSSLCAChanged(files) {
-    this.state.currentConnection.sslCA = files;
+    this.state.connectionModel.sslCA = files;
     this.trigger(this.state);
   },
 
@@ -662,7 +662,7 @@ const Store = Reflux.createStore({
    * @param {Array} files - The files.
    */
   onSSLCertificateChanged(files) {
-    this.state.currentConnection.sslCert = files;
+    this.state.connectionModel.sslCert = files;
     this.trigger(this.state);
   },
 
@@ -673,7 +673,7 @@ const Store = Reflux.createStore({
    */
   onSSLMethodChanged(method) {
     this._clearSSLFields();
-    this.state.currentConnection.sslMethod = method;
+    this.state.connectionModel.sslMethod = method;
     this.trigger(this.state);
   },
 
@@ -683,7 +683,7 @@ const Store = Reflux.createStore({
    * @param {Array} files - The files.
    */
   onSSLPrivateKeyChanged(files) {
-    this.state.currentConnection.sslKey = files;
+    this.state.connectionModel.sslKey = files;
     this.trigger(this.state);
   },
 
@@ -693,7 +693,7 @@ const Store = Reflux.createStore({
    * @param {String} password - The password.
    */
   onSSLPrivateKeyPasswordChanged(password) {
-    this.state.currentConnection.sslPass = password;
+    this.state.connectionModel.sslPass = password;
     this.trigger(this.state);
   },
 
@@ -703,7 +703,7 @@ const Store = Reflux.createStore({
    * @param {String} password - The password.
    */
   onSSHTunnelPasswordChanged(password) {
-    this.state.currentConnection.sshTunnelPassword = password;
+    this.state.connectionModel.sshTunnelPassword = password;
     this.trigger(this.state);
   },
 
@@ -713,7 +713,7 @@ const Store = Reflux.createStore({
    * @param {String} passphrase - The passphrase.
    */
   onSSHTunnelPassphraseChanged(passphrase) {
-    this.state.currentConnection.sshTunnelPassphrase = passphrase;
+    this.state.connectionModel.sshTunnelPassphrase = passphrase;
     this.trigger(this.state);
   },
 
@@ -723,7 +723,7 @@ const Store = Reflux.createStore({
    * @param {String} hostname - The hostname.
    */
   onSSHTunnelHostnameChanged(hostname) {
-    this.state.currentConnection.sshTunnelHostname = hostname;
+    this.state.connectionModel.sshTunnelHostname = hostname;
     this.trigger(this.state);
   },
 
@@ -733,7 +733,7 @@ const Store = Reflux.createStore({
    * @param {String} username - The username.
    */
   onSSHTunnelUsernameChanged(username) {
-    this.state.currentConnection.sshTunnelUsername = username;
+    this.state.connectionModel.sshTunnelUsername = username;
     this.trigger(this.state);
   },
 
@@ -743,7 +743,7 @@ const Store = Reflux.createStore({
    * @param {String} port - The port.
    */
   onSSHTunnelPortChanged(port) {
-    this.state.currentConnection.sshTunnelPort = port;
+    this.state.connectionModel.sshTunnelPort = port;
     this.trigger(this.state);
   },
 
@@ -753,7 +753,7 @@ const Store = Reflux.createStore({
    * @param {Array} files - The file.
    */
   onSSHTunnelIdentityFileChanged(files) {
-    this.state.currentConnection.sshTunnelIdentityFile = files;
+    this.state.connectionModel.sshTunnelIdentityFile = files;
     this.trigger(this.state);
   },
 
@@ -764,7 +764,7 @@ const Store = Reflux.createStore({
    */
   onSSHTunnelChanged(tunnel) {
     this._clearSSHTunnelFields();
-    this.state.currentConnection.sshTunnel = tunnel;
+    this.state.connectionModel.sshTunnel = tunnel;
     this.trigger(this.state);
   },
 
@@ -772,7 +772,7 @@ const Store = Reflux.createStore({
    * Changes the srv record flag.
    */
   onSRVRecordToggled() {
-    this.state.currentConnection.isSrvRecord = !this.state.currentConnection
+    this.state.connectionModel.isSrvRecord = !this.state.connectionModel
       .isSrvRecord;
     this.trigger(this.state);
   },
@@ -783,7 +783,7 @@ const Store = Reflux.createStore({
    * @param {String} username - The username.
    */
   onUsernameChanged(username) {
-    this.state.currentConnection.mongodbUsername = username;
+    this.state.connectionModel.mongodbUsername = username;
     this.trigger(this.state);
   },
 
@@ -795,7 +795,7 @@ const Store = Reflux.createStore({
    * @param {Object} connection - A connection.
    */
   _saveConnection(connection) {
-    this.state.currentConnection = connection;
+    this.state.connectionModel = connection;
     this.state.fetchedConnections.add(connection);
     this.state.connections[connection._id] = { ...connection._values };
     this.state.customUrl = connection.safeUrl;
@@ -808,7 +808,7 @@ const Store = Reflux.createStore({
    */
   _clearAuthFields() {
     AUTH_FIELDS.forEach((field) => {
-      this.state.currentConnection[field] = undefined;
+      this.state.connectionModel[field] = undefined;
     });
   },
 
@@ -817,7 +817,7 @@ const Store = Reflux.createStore({
    */
   _clearSSLFields() {
     SSL_FIELDS.forEach((field) => {
-      this.state.currentConnection[field] = undefined;
+      this.state.connectionModel[field] = undefined;
     });
   },
 
@@ -826,7 +826,7 @@ const Store = Reflux.createStore({
    */
   _clearSSHTunnelFields() {
     SSH_TUNNEL_FIELDS.forEach((field) => {
-      this.state.currentConnection[field] = undefined;
+      this.state.connectionModel[field] = undefined;
     });
   },
 
@@ -855,9 +855,9 @@ const Store = Reflux.createStore({
   /**
    * Saves the current connection to recents.
    *
-   * @param {Object} currentConnection - The current connection.
+   * @param {Object} connectionModel - The current connection.
    */
-  _saveRecent(currentConnection) {
+  _saveRecent(connectionModel) {
     // Keeps 10 recent connections and deletes rest of them.
     let recents = Object.keys(this.state.connections).filter(
       (key) => !this.state.connections[key].isFavorite
@@ -874,17 +874,17 @@ const Store = Reflux.createStore({
       toDestroy.destroy({
         success: () => {
           this.state.fetchedConnections.remove(toDestroy._id);
-          this._saveConnection(currentConnection);
+          this._saveConnection(connectionModel);
         }
       });
     } else {
-      this._saveConnection(currentConnection);
+      this._saveConnection(connectionModel);
     }
   },
 
   _onConnectSuccess(dataService) {
-    const currentConnection = this.state.currentConnection;
-    const currentSaved = this.state.connections[currentConnection._id];
+    const connectionModel = this.state.connectionModel;
+    const currentSaved = this.state.connections[connectionModel._id];
 
     this.dataService = dataService;
 
@@ -895,15 +895,15 @@ const Store = Reflux.createStore({
       syntaxErrorMessage: null,
       hasUnsavedChanges: false,
       isURIEditable: false,
-      customUrl: currentConnection.driverUrl
+      customUrl: connectionModel.driverUrl
     });
 
-    currentConnection.lastUsed = new Date();
+    connectionModel.lastUsed = new Date();
 
     if (currentSaved) {
-      this._saveConnection(currentConnection);
+      this._saveConnection(connectionModel);
     } else {
-      this._saveRecent(currentConnection);
+      this._saveRecent(connectionModel);
     }
 
     this.appRegistry.emit(
@@ -958,10 +958,10 @@ const Store = Reflux.createStore({
    * Connects to the current connection form connection configuration.
    */
   async _connectWithConnectionForm() {
-    const currentConnection = this.state.currentConnection;
+    const connectionModel = this.state.connectionModel;
 
-    if (!currentConnection.isValid()) {
-      const validationError = currentConnection.validate(currentConnection);
+    if (!connectionModel.isValid()) {
+      const validationError = connectionModel.validate(connectionModel);
 
       this.setState({
         isValid: false,
@@ -973,21 +973,21 @@ const Store = Reflux.createStore({
     }
 
     this.setState({
-      connectingStatusText: `Connecting to ${currentConnection.title}`
+      connectingStatusText: `Connecting to ${connectionModel.title}`
     });
 
-    await this._connect(currentConnection);
+    await this._connect(connectionModel);
   },
 
   /**
    * Connects to the current connection string connection.
    */
   async _connectWithConnectionString() {
-    const currentConnection = this.state.currentConnection;
+    const connectionModel = this.state.connectionModel;
 
     const url = this.state.isURIEditable
       ? (this.state.customUrl || DEFAULT_DRIVER_URL)
-      : this.state.currentConnection.driverUrl;
+      : this.state.connectionModel.driverUrl;
 
     if (!Connection.isURI(url)) {
       this._setSyntaxErrorMessage(
@@ -1006,16 +1006,16 @@ const Store = Reflux.createStore({
       return;
     }
 
-    const isFavorite = currentConnection.isFavorite;
-    const driverUrl = currentConnection.driverUrl;
+    const isFavorite = connectionModel.isFavorite;
+    const driverUrl = connectionModel.driverUrl;
 
     // If we have SSH tunnel attributes, set them here.
-    if (currentConnection && currentConnection.sshTunnel !== 'NONE') {
-      this._setSshTunnelAttributes(currentConnection, parsedConnection);
+    if (connectionModel && connectionModel.sshTunnel !== 'NONE') {
+      this._setSshTunnelAttributes(connectionModel, parsedConnection);
     }
 
-    if (currentConnection && currentConnection.sslMethod !== 'NONE') {
-      this._setTlsAttributes(currentConnection, parsedConnection);
+    if (connectionModel && connectionModel.sslMethod !== 'NONE') {
+      this._setTlsAttributes(connectionModel, parsedConnection);
     }
 
     this.setState({
@@ -1025,8 +1025,8 @@ const Store = Reflux.createStore({
     if (isFavorite && driverUrl !== parsedConnection.driverUrl) {
       await this._connect(parsedConnection);
     } else {
-      currentConnection.set(this._getPoorAttributes(parsedConnection));
-      await this._connect(currentConnection);
+      connectionModel.set(this._getPoorAttributes(parsedConnection));
+      await this._connect(connectionModel);
     }
   },
 
@@ -1034,13 +1034,13 @@ const Store = Reflux.createStore({
    * Clears the current connection.
    */
   _clearConnection() {
-    const isFavorite = this.state.currentConnection.isFavorite;
-    const name = this.state.currentConnection.name;
-    const color = this.state.currentConnection.color;
+    const isFavorite = this.state.connectionModel.isFavorite;
+    const name = this.state.connectionModel.name;
+    const color = this.state.connectionModel.color;
     const connection = new Connection();
 
-    this.state.currentConnection.set(this._getPoorAttributes(connection));
-    this.state.currentConnection.set({ isFavorite, name, color });
+    this.state.connectionModel.set(this._getPoorAttributes(connection));
+    this.state.connectionModel.set({ isFavorite, name, color });
     this.trigger(this.state);
   },
 
@@ -1057,10 +1057,10 @@ const Store = Reflux.createStore({
   },
 
   async _onViewChangedToConnectionForm() {
-    const currentConnection = this.state.currentConnection;
-    const driverUrl = currentConnection.driverUrl;
+    const connectionModel = this.state.connectionModel;
+    const driverUrl = connectionModel.driverUrl;
     const url = this.state.isURIEditable ? this.state.customUrl : driverUrl;
-    const currentSaved = this.state.connections[currentConnection._id];
+    const currentSaved = this.state.connections[connectionModel._id];
 
     if (!currentSaved && url === driverUrl) {
       this.state.isHostChanged = true;
@@ -1090,43 +1090,43 @@ const Store = Reflux.createStore({
 
       this.StatusActions.done();
 
-      currentConnection.set(this._getPoorAttributes(parsedConnection));
+      connectionModel.set(this._getPoorAttributes(parsedConnection));
 
       if (currentSaved) {
         // If we have SSH tunnel attributes, set them here.
         if (currentSaved.sshTunnel !== 'NONE') {
-          this._setSshTunnelAttributes(currentSaved, currentConnection);
+          this._setSshTunnelAttributes(currentSaved, connectionModel);
         }
 
         // If we have TLS attributes, set them here.
         if (currentSaved.sslMethod !== 'NONE') {
-          this._setTlsAttributes(currentSaved, currentConnection);
+          this._setTlsAttributes(currentSaved, connectionModel);
         }
 
-        currentConnection.name = currentSaved.name;
-        currentConnection.color = currentSaved.color;
-        currentConnection.lastUsed = currentSaved.lastUsed;
+        connectionModel.name = currentSaved.name;
+        connectionModel.color = currentSaved.color;
+        connectionModel.lastUsed = currentSaved.lastUsed;
       }
 
       this.state.isHostChanged = true;
       this.state.isPortChanged = true;
-      this.setState({ currentConnection });
+      this.setState({ connectionModel });
       this._resetSyntaxErrorMessage();
     } catch (error) {
       this.StatusActions.done();
 
-      this.state.currentConnection = new Connection();
+      this.state.connectionModel = new Connection();
       this.trigger(this.state);
     }
   },
 
   _onViewChangedToConnectionString() {
-    const currentConnection = this.state.currentConnection;
-    const driverUrl = currentConnection.driverUrl;
+    const connectionModel = this.state.connectionModel;
+    const driverUrl = connectionModel.driverUrl;
     const isValid = this.state.isValid;
 
     if (!this.state.isURIEditable) {
-      this.state.customUrl = this.state.currentConnection.safeUrl;
+      this.state.customUrl = this.state.connectionModel.safeUrl;
     } else if (
       isValid &&
       (this.state.isHostChanged === true || this.state.isPortChanged === true)
@@ -1141,8 +1141,8 @@ const Store = Reflux.createStore({
    * Persist a favorite on disc.
    */
   async _saveFavorite() {
-    const currentConnection = this.state.currentConnection;
-    const isFavorite = currentConnection.isFavorite;
+    const connectionModel = this.state.connectionModel;
+    const isFavorite = connectionModel.isFavorite;
     let url = this.state.customUrl;
 
     if (isFavorite) {
@@ -1150,10 +1150,10 @@ const Store = Reflux.createStore({
     }
 
     if (!this.state.isURIEditable) {
-      url = currentConnection.driverUrl;
+      url = connectionModel.driverUrl;
     }
 
-    currentConnection.isFavorite = true;
+    connectionModel.isFavorite = true;
     this.state.hasUnsavedChanges = false;
     this.state.isURIEditable = false;
 
@@ -1162,17 +1162,17 @@ const Store = Reflux.createStore({
         const buildConnectionModelFromUrl = promisify(Connection.from);
         const parsedConnection = await buildConnectionModelFromUrl(url);
 
-        currentConnection.set(this._getPoorAttributes(parsedConnection));
+        connectionModel.set(this._getPoorAttributes(parsedConnection));
 
         if (url.match(/[?&]ssl=true/i)) {
-          currentConnection.sslMethod = 'SYSTEMCA';
+          connectionModel.sslMethod = 'SYSTEMCA';
         }
 
-        this._saveConnection(currentConnection);
+        this._saveConnection(connectionModel);
       } catch (error) { /* Ignore saving invalid connection string */ }
     } else if (this.state.viewType === CONNECTION_FORM_VIEW) {
-      if (!currentConnection.isValid()) {
-        const validationError = currentConnection.validate(currentConnection);
+      if (!connectionModel.isValid()) {
+        const validationError = connectionModel.validate(connectionModel);
 
         this.setState({
           isValid: false,
@@ -1183,7 +1183,7 @@ const Store = Reflux.createStore({
         return;
       }
 
-      this._saveConnection(currentConnection);
+      this._saveConnection(connectionModel);
     }
   },
 
@@ -1216,30 +1216,30 @@ const Store = Reflux.createStore({
   /**
    * Set SSH tunnel attributes.
    *
-   * @param {Connection} currentConnection - The current connection.
+   * @param {Connection} connectionModel - The current connection.
    * @param {Connection} parsedConnection - The parsed connection.
    */
-  _setSshTunnelAttributes(currentConnection, parsedConnection) {
+  _setSshTunnelAttributes(connectionModel, parsedConnection) {
     if (parsedConnection) {
       SSH_TUNNEL_FIELDS.forEach((field) => {
-        parsedConnection[field] = currentConnection[field];
+        parsedConnection[field] = connectionModel[field];
       });
-      parsedConnection.sshTunnel = currentConnection.sshTunnel;
+      parsedConnection.sshTunnel = connectionModel.sshTunnel;
     }
   },
 
   /**
    * Set TLS attributes.
    *
-   * @param {Connection} currentConnection - The current connection.
+   * @param {Connection} connectionModel - The current connection.
    * @param {Connection} parsedConnection - The parsed connection.
    */
-  _setTlsAttributes(currentConnection, parsedConnection) {
+  _setTlsAttributes(connectionModel, parsedConnection) {
     if (parsedConnection) {
       SSL_FIELDS.forEach((field) => {
-        parsedConnection[field] = currentConnection[field];
+        parsedConnection[field] = connectionModel[field];
       });
-      parsedConnection.sslMethod = currentConnection.sslMethod;
+      parsedConnection.sslMethod = connectionModel.sslMethod;
     }
   }
 });

--- a/test/renderer/components/connect.spec.js
+++ b/test/renderer/components/connect.spec.js
@@ -29,7 +29,7 @@ describe('Connect [Component]', () => {
 
     beforeEach(() => {
       component = shallow(
-        <Connect currentConnection={connection} connections={connections} isValid />
+        <Connect connectionModel={connection} connections={connections} isValid />
       );
     });
 
@@ -62,7 +62,7 @@ describe('Connect [Component]', () => {
     beforeEach(() => {
       component = shallow(
         <Connect
-          currentConnection={connection}
+          connectionModel={connection}
           connections={connections}
           isConnected
           isValid />

--- a/test/renderer/components/scram-sha-256.spec.js
+++ b/test/renderer/components/scram-sha-256.spec.js
@@ -16,7 +16,7 @@ describe('ScramSha256 [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <ScramSha256 currentConnection={connection} isValid />
+          <ScramSha256 connectionModel={connection} isValid />
         );
       });
 
@@ -67,7 +67,7 @@ describe('ScramSha256 [Component]', () => {
         let component;
 
         beforeEach(() => {
-          component = mount(<ScramSha256 currentConnection={connection} />);
+          component = mount(<ScramSha256 connectionModel={connection} />);
         });
 
         afterEach(() => {
@@ -95,7 +95,7 @@ describe('ScramSha256 [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <ScramSha256 currentConnection={connection} />
+            <ScramSha256 connectionModel={connection} />
           );
         });
 
@@ -124,7 +124,7 @@ describe('ScramSha256 [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <ScramSha256 currentConnection={connection} />
+            <ScramSha256 connectionModel={connection} />
           );
         });
 
@@ -153,7 +153,7 @@ describe('ScramSha256 [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <ScramSha256 currentConnection={connection} />
+            <ScramSha256 connectionModel={connection} />
           );
         });
 
@@ -182,7 +182,7 @@ describe('ScramSha256 [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <ScramSha256 currentConnection={connection} />
+            <ScramSha256 connectionModel={connection} />
           );
         });
 
@@ -211,7 +211,7 @@ describe('ScramSha256 [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <ScramSha256 currentConnection={connection} />
+            <ScramSha256 connectionModel={connection} />
           );
         });
 

--- a/test/renderer/components/ssh-tunnel-identity-file-validation.spec.js
+++ b/test/renderer/components/ssh-tunnel-identity-file-validation.spec.js
@@ -19,7 +19,7 @@ describe('SSHTunnelIdentityFile [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <SSHTunnelIdentityFile currentConnection={connection} isValid />
+          <SSHTunnelIdentityFile connectionModel={connection} isValid />
         );
       });
 
@@ -85,7 +85,7 @@ describe('SSHTunnelIdentityFile [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSHTunnelIdentityFile currentConnection={connection} />
+            <SSHTunnelIdentityFile connectionModel={connection} />
           );
         });
 
@@ -113,7 +113,7 @@ describe('SSHTunnelIdentityFile [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSHTunnelIdentityFile currentConnection={connection} />
+            <SSHTunnelIdentityFile connectionModel={connection} />
           );
         });
 
@@ -141,7 +141,7 @@ describe('SSHTunnelIdentityFile [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSHTunnelIdentityFile currentConnection={connection} />
+            <SSHTunnelIdentityFile connectionModel={connection} />
           );
         });
 
@@ -169,7 +169,7 @@ describe('SSHTunnelIdentityFile [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSHTunnelIdentityFile currentConnection={connection} />
+            <SSHTunnelIdentityFile connectionModel={connection} />
           );
         });
 

--- a/test/renderer/components/ssh-tunnel-password-validation.spec.js
+++ b/test/renderer/components/ssh-tunnel-password-validation.spec.js
@@ -18,7 +18,7 @@ describe('SSHTunnelPassword [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <SSHTunnelPassword currentConnection={connection} isValid />
+          <SSHTunnelPassword connectionModel={connection} isValid />
         );
       });
 
@@ -66,7 +66,7 @@ describe('SSHTunnelPassword [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSHTunnelPassword currentConnection={connection} />
+            <SSHTunnelPassword connectionModel={connection} />
           );
         });
 
@@ -93,7 +93,7 @@ describe('SSHTunnelPassword [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSHTunnelPassword currentConnection={connection} />
+            <SSHTunnelPassword connectionModel={connection} />
           );
         });
 
@@ -120,7 +120,7 @@ describe('SSHTunnelPassword [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSHTunnelPassword currentConnection={connection} />
+            <SSHTunnelPassword connectionModel={connection} />
           );
         });
 
@@ -147,7 +147,7 @@ describe('SSHTunnelPassword [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSHTunnelPassword currentConnection={connection} />
+            <SSHTunnelPassword connectionModel={connection} />
           );
         });
 

--- a/test/renderer/components/ssl-server-client-validation.spec.js
+++ b/test/renderer/components/ssl-server-client-validation.spec.js
@@ -18,7 +18,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <SSLServerClientValidation currentConnection={connection} isValid />
+          <SSLServerClientValidation connectionModel={connection} isValid />
         );
       });
 
@@ -77,7 +77,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerClientValidation currentConnection={connection} />
+            <SSLServerClientValidation connectionModel={connection} />
           );
         });
 
@@ -104,7 +104,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerClientValidation currentConnection={connection} />
+            <SSLServerClientValidation connectionModel={connection} />
           );
         });
 
@@ -130,7 +130,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerClientValidation currentConnection={connection} />
+            <SSLServerClientValidation connectionModel={connection} />
           );
         });
 
@@ -157,7 +157,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerClientValidation currentConnection={connection} />
+            <SSLServerClientValidation connectionModel={connection} />
           );
         });
 
@@ -184,7 +184,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerClientValidation currentConnection={connection} />
+            <SSLServerClientValidation connectionModel={connection} />
           );
         });
 
@@ -210,7 +210,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerClientValidation currentConnection={connection} />
+            <SSLServerClientValidation connectionModel={connection} />
           );
         });
 
@@ -237,7 +237,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerClientValidation currentConnection={connection} />
+            <SSLServerClientValidation connectionModel={connection} />
           );
         });
 
@@ -264,7 +264,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerClientValidation currentConnection={connection} />
+            <SSLServerClientValidation connectionModel={connection} />
           );
         });
 
@@ -290,7 +290,7 @@ describe('SSLServerClientValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerClientValidation currentConnection={connection} />
+            <SSLServerClientValidation connectionModel={connection} />
           );
         });
 

--- a/test/renderer/components/ssl-server-validation.spec.js
+++ b/test/renderer/components/ssl-server-validation.spec.js
@@ -13,7 +13,7 @@ describe('SSLServerValidation [Component]', () => {
 
       beforeEach(() => {
         component = mount(
-          <SSLServerValidation currentConnection={connection} isValid />
+          <SSLServerValidation connectionModel={connection} isValid />
         );
       });
 
@@ -41,7 +41,7 @@ describe('SSLServerValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerValidation currentConnection={connection} />
+            <SSLServerValidation connectionModel={connection} />
           );
         });
 
@@ -64,7 +64,7 @@ describe('SSLServerValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerValidation currentConnection={connection} />
+            <SSLServerValidation connectionModel={connection} />
           );
         });
 
@@ -87,7 +87,7 @@ describe('SSLServerValidation [Component]', () => {
 
         beforeEach(() => {
           component = mount(
-            <SSLServerValidation currentConnection={connection} />
+            <SSLServerValidation connectionModel={connection} />
           );
         });
 

--- a/test/renderer/stores/index.spec.js
+++ b/test/renderer/stores/index.spec.js
@@ -29,11 +29,11 @@ describe('Store', () => {
 
   describe('#getInitialState', () => {
     it('initializes with an empty current connection', () => {
-      expect(Store.state.currentConnection).to.exist;
-      expect(Store.state.currentConnection.username).to.equal('');
-      expect(Store.state.currentConnection.hostname).to.equal('localhost');
-      expect(Store.state.currentConnection.port).to.equal(27017);
-      expect(Store.state.currentConnection.connectionType).to.equal(
+      expect(Store.state.connectionModel).to.exist;
+      expect(Store.state.connectionModel.username).to.equal('');
+      expect(Store.state.connectionModel.hostname).to.equal('localhost');
+      expect(Store.state.connectionModel.port).to.equal(27017);
+      expect(Store.state.connectionModel.connectionType).to.equal(
         'NODE_DRIVER'
       );
     });
@@ -42,7 +42,7 @@ describe('Store', () => {
   describe('#onActivated', () => {
     const ExtActions = Reflux.createActions(['onKerberosPrincipalChanged']);
     const onKerberosPrincipalChanged = function(principal) {
-      this.state.currentConnection.kerberosPrincipal = principal;
+      this.state.connectionModel.kerberosPrincipal = principal;
       this.trigger(this.state);
     };
     const extension = function(store) {
@@ -61,8 +61,8 @@ describe('Store', () => {
     it('binds the store context to the extension', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.kerberosPrincipal).to.equal('testing');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.kerberosPrincipal).to.equal('testing');
         done();
       });
 
@@ -75,16 +75,16 @@ describe('Store', () => {
       const connection = new Connection({ mongodbUsername: 'testing' });
 
       beforeEach(() => {
-        Store.state.currentConnection = connection;
+        Store.state.connectionModel = connection;
         Store.state.isURIEditable = false;
       });
 
       it('updates the hostname and id in the current connection model', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
-          expect(state.currentConnection).to.exist;
-          expect(state.currentConnection.mongodbUsername).to.equal(undefined);
-          expect(state.currentConnection._id).to.not.equal(connection._id);
+          expect(state.connectionModel).to.exist;
+          expect(state.connectionModel.mongodbUsername).to.equal(undefined);
+          expect(state.connectionModel._id).to.not.equal(connection._id);
           expect(state.isURIEditable).to.equal(true);
           done();
         });
@@ -252,8 +252,8 @@ describe('Store', () => {
     it('updates the hostname in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.hostname).to.equal('myserver');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.hostname).to.equal('myserver');
         done();
       });
 
@@ -264,9 +264,9 @@ describe('Store', () => {
       it('updates the hostname and sets the systemca ssl option', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
-          expect(state.currentConnection).to.exist;
-          expect(state.currentConnection.hostname).to.equal('mongodb.net');
-          expect(state.currentConnection.sslMethod).to.equal('SYSTEMCA');
+          expect(state.connectionModel).to.exist;
+          expect(state.connectionModel.hostname).to.equal('mongodb.net');
+          expect(state.connectionModel.sslMethod).to.equal('SYSTEMCA');
           done();
         });
 
@@ -278,8 +278,8 @@ describe('Store', () => {
       it('trims the whitespace', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
-          expect(state.currentConnection).to.exist;
-          expect(state.currentConnection.hostname).to.equal('example.com');
+          expect(state.connectionModel).to.exist;
+          expect(state.connectionModel.hostname).to.equal('example.com');
           done();
         });
 
@@ -290,14 +290,14 @@ describe('Store', () => {
 
   describe('#onSRVRecordToggled', () => {
     afterEach(() => {
-      Store.state.currentConnection.isSrvRecord = false;
+      Store.state.connectionModel.isSrvRecord = false;
     });
 
     it('updates the srv record property', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.isSrvRecord).to.equal(true);
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.isSrvRecord).to.equal(true);
         done();
       });
       Actions.onSRVRecordToggled();
@@ -308,8 +308,8 @@ describe('Store', () => {
     it('updates the port in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.port).to.equal(27018);
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.port).to.equal(27018);
         done();
       });
 
@@ -321,8 +321,8 @@ describe('Store', () => {
     it('updates the replica set name in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.replicaSet).to.equal('myreplicaset');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.replicaSet).to.equal('myreplicaset');
         done();
       });
 
@@ -333,8 +333,8 @@ describe('Store', () => {
       it('trims the whitespace', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
-          expect(state.currentConnection).to.exist;
-          expect(state.currentConnection.replicaSet).to.equal('myreplicaset');
+          expect(state.connectionModel).to.exist;
+          expect(state.connectionModel.replicaSet).to.equal('myreplicaset');
           done();
         });
 
@@ -347,8 +347,8 @@ describe('Store', () => {
     it('updates the read preference in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.readPreference).to.equal(
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.readPreference).to.equal(
           'primaryPreferred'
         );
         done();
@@ -362,8 +362,8 @@ describe('Store', () => {
     it('updates the ssh method in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sshTunnel).to.equal('IDENTITY_FILE');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sshTunnel).to.equal('IDENTITY_FILE');
         done();
       });
 
@@ -372,30 +372,30 @@ describe('Store', () => {
 
     context('when ssl attributes already exist', () => {
       beforeEach(() => {
-        Store.state.currentConnection.sshTunnelHostname = 'host';
-        Store.state.currentConnection.sshTunnelPort = '3000';
-        Store.state.currentConnection.sshTunnelBindToLocalPort = '5000';
-        Store.state.currentConnection.sshTunnelUsername = 'user';
-        Store.state.currentConnection.sshTunnelPassword = 'pass';
-        Store.state.currentConnection.sshTunnelPassphrase = 'pp';
+        Store.state.connectionModel.sshTunnelHostname = 'host';
+        Store.state.connectionModel.sshTunnelPort = '3000';
+        Store.state.connectionModel.sshTunnelBindToLocalPort = '5000';
+        Store.state.connectionModel.sshTunnelUsername = 'user';
+        Store.state.connectionModel.sshTunnelPassword = 'pass';
+        Store.state.connectionModel.sshTunnelPassphrase = 'pp';
       });
 
       it('clears out all previous values', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
-          expect(state.currentConnection).to.exist;
-          expect(state.currentConnection.sshTunnel).to.equal('IDENTITY_FILE');
-          expect(state.currentConnection.sshTunnelHostname).to.equal(undefined);
-          expect(state.currentConnection.sshTunnelPort).to.equal(22);
-          expect(state.currentConnection.sshTunnelBindToLocalPort).to.equal(
+          expect(state.connectionModel).to.exist;
+          expect(state.connectionModel.sshTunnel).to.equal('IDENTITY_FILE');
+          expect(state.connectionModel.sshTunnelHostname).to.equal(undefined);
+          expect(state.connectionModel.sshTunnelPort).to.equal(22);
+          expect(state.connectionModel.sshTunnelBindToLocalPort).to.equal(
             undefined
           );
-          expect(state.currentConnection.sshTunnelUsername).to.equal(undefined);
-          expect(state.currentConnection.sshTunnelPassword).to.equal(undefined);
-          expect(state.currentConnection.sshTunnelIdentityFile).to.equal(
+          expect(state.connectionModel.sshTunnelUsername).to.equal(undefined);
+          expect(state.connectionModel.sshTunnelPassword).to.equal(undefined);
+          expect(state.connectionModel.sshTunnelIdentityFile).to.equal(
             undefined
           );
-          expect(state.currentConnection.sshTunnelPassphrase).to.equal(
+          expect(state.connectionModel.sshTunnelPassphrase).to.equal(
             undefined
           );
           done();
@@ -410,8 +410,8 @@ describe('Store', () => {
     it('updates the ssl method in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sslMethod).to.equal('SYSTEMCA');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sslMethod).to.equal('SYSTEMCA');
         done();
       });
 
@@ -420,21 +420,21 @@ describe('Store', () => {
 
     context('when ssl attributes already exist', () => {
       beforeEach(() => {
-        Store.state.currentConnection.sslCA = ['ca'];
-        Store.state.currentConnection.sslCert = ['cert'];
-        Store.state.currentConnection.sslKey = ['key'];
-        Store.state.currentConnection.sslPass = 'pass';
+        Store.state.connectionModel.sslCA = ['ca'];
+        Store.state.connectionModel.sslCert = ['cert'];
+        Store.state.connectionModel.sslKey = ['key'];
+        Store.state.connectionModel.sslPass = 'pass';
       });
 
       it('clears out all previous values', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
-          expect(state.currentConnection).to.exist;
-          expect(state.currentConnection.sslMethod).to.equal('SYSTEMCA');
-          expect(state.currentConnection.sslCert).to.equal(undefined);
-          expect(state.currentConnection.sslKey).to.equal(undefined);
-          expect(state.currentConnection.sslCA).to.equal(undefined);
-          expect(state.currentConnection.sslPass).to.equal(undefined);
+          expect(state.connectionModel).to.exist;
+          expect(state.connectionModel.sslMethod).to.equal('SYSTEMCA');
+          expect(state.connectionModel.sslCert).to.equal(undefined);
+          expect(state.connectionModel.sslKey).to.equal(undefined);
+          expect(state.connectionModel.sslCA).to.equal(undefined);
+          expect(state.connectionModel.sslPass).to.equal(undefined);
           done();
         });
 
@@ -447,8 +447,8 @@ describe('Store', () => {
     it('updates the authentication method in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.authStrategy).to.equal('MONGODB');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.authStrategy).to.equal('MONGODB');
         done();
       });
 
@@ -457,33 +457,33 @@ describe('Store', () => {
 
     context('when auth attributes already exist', () => {
       beforeEach(() => {
-        Store.state.currentConnection.mongodbUsername = 'user';
-        Store.state.currentConnection.mongodbPassword = 'password';
-        Store.state.currentConnection.mongodbDatabaseName = 'foo';
-        Store.state.currentConnection.kerberosPrincipal = 'kerb';
-        Store.state.currentConnection.kerberosServiceName = 'kerb-service';
-        Store.state.currentConnection.x509Username = 'x5user';
-        Store.state.currentConnection.ldapUsername = 'ldapuser';
-        Store.state.currentConnection.ldapPassword = 'ldappass';
+        Store.state.connectionModel.mongodbUsername = 'user';
+        Store.state.connectionModel.mongodbPassword = 'password';
+        Store.state.connectionModel.mongodbDatabaseName = 'foo';
+        Store.state.connectionModel.kerberosPrincipal = 'kerb';
+        Store.state.connectionModel.kerberosServiceName = 'kerb-service';
+        Store.state.connectionModel.x509Username = 'x5user';
+        Store.state.connectionModel.ldapUsername = 'ldapuser';
+        Store.state.connectionModel.ldapPassword = 'ldappass';
       });
 
       it('clears out all previous values', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
-          expect(state.currentConnection).to.exist;
-          expect(state.currentConnection.authStrategy).to.equal('MONGODB');
-          expect(state.currentConnection.mongodbUsername).to.equal(undefined);
-          expect(state.currentConnection.mongodbPassword).to.equal(undefined);
-          expect(state.currentConnection.mongodbDatabaseName).to.equal(
+          expect(state.connectionModel).to.exist;
+          expect(state.connectionModel.authStrategy).to.equal('MONGODB');
+          expect(state.connectionModel.mongodbUsername).to.equal(undefined);
+          expect(state.connectionModel.mongodbPassword).to.equal(undefined);
+          expect(state.connectionModel.mongodbDatabaseName).to.equal(
             undefined
           );
-          expect(state.currentConnection.kerberosPrincipal).to.equal(undefined);
-          expect(state.currentConnection.kerberosServiceName).to.equal(
+          expect(state.connectionModel.kerberosPrincipal).to.equal(undefined);
+          expect(state.connectionModel.kerberosServiceName).to.equal(
             undefined
           );
-          expect(state.currentConnection.x509Username).to.equal(undefined);
-          expect(state.currentConnection.ldapUsername).to.equal(undefined);
-          expect(state.currentConnection.ldapPassword).to.equal(undefined);
+          expect(state.connectionModel.x509Username).to.equal(undefined);
+          expect(state.connectionModel.ldapUsername).to.equal(undefined);
+          expect(state.connectionModel.ldapPassword).to.equal(undefined);
           done();
         });
 
@@ -496,8 +496,8 @@ describe('Store', () => {
     it('updates the username in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.mongodbUsername).to.equal('user');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.mongodbUsername).to.equal('user');
         done();
       });
 
@@ -509,8 +509,8 @@ describe('Store', () => {
     it('updates the password in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.mongodbPassword).to.equal('pass');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.mongodbPassword).to.equal('pass');
         done();
       });
 
@@ -522,8 +522,8 @@ describe('Store', () => {
     it('updates the auth source in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.mongodbDatabaseName).to.equal(
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.mongodbDatabaseName).to.equal(
           'database'
         );
         done();
@@ -537,8 +537,8 @@ describe('Store', () => {
     it('updates the ssl ca field in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sslCA).to.deep.equal(['file']);
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sslCA).to.deep.equal(['file']);
         done();
       });
 
@@ -550,8 +550,8 @@ describe('Store', () => {
     it('updates the ssl certificate field in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sslCert).to.deep.equal(['file']);
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sslCert).to.deep.equal(['file']);
         done();
       });
 
@@ -563,8 +563,8 @@ describe('Store', () => {
     it('updates the ssl private key field in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sslKey).to.deep.equal(['file']);
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sslKey).to.deep.equal(['file']);
         done();
       });
 
@@ -576,8 +576,8 @@ describe('Store', () => {
     it('updates the ssl private key password field in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sslPass).to.equal('testing');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sslPass).to.equal('testing');
         done();
       });
 
@@ -589,8 +589,8 @@ describe('Store', () => {
     it('updates the SSH Tunnel port in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sshTunnelPort).to.equal('5000');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sshTunnelPort).to.equal('5000');
         done();
       });
 
@@ -602,8 +602,8 @@ describe('Store', () => {
     it('updates the SSH Tunnel username in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sshTunnelUsername).to.equal('mongodb');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sshTunnelUsername).to.equal('mongodb');
         done();
       });
 
@@ -615,8 +615,8 @@ describe('Store', () => {
     it('updates the SSH Tunnel hostname in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sshTunnelHostname).to.equal('localhost');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sshTunnelHostname).to.equal('localhost');
         done();
       });
 
@@ -628,8 +628,8 @@ describe('Store', () => {
     it('updates the SSH Tunnel password in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sshTunnelPassword).to.equal('mongodb');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sshTunnelPassword).to.equal('mongodb');
         done();
       });
 
@@ -641,8 +641,8 @@ describe('Store', () => {
     it('updates the SSH Tunnel passphrase in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sshTunnelPassphrase).to.equal('mongodb');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sshTunnelPassphrase).to.equal('mongodb');
         done();
       });
 
@@ -654,8 +654,8 @@ describe('Store', () => {
     it('updates the SSH Tunnel identity file in the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.sshTunnelIdentityFile).to.deep.equal([
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.sshTunnelIdentityFile).to.deep.equal([
           'file'
         ]);
         done();
@@ -668,7 +668,7 @@ describe('Store', () => {
   describe('#onConnectionSelected', () => {
     context('when the current connection ia a new connection', () => {
       context('when a favorite is being selected', () => {
-        const currentConnection = new Connection();
+        const connectionModel = new Connection();
         const favoriteConnection = new Connection({
           name: 'MyFav',
           color: '#59c1e2',
@@ -681,7 +681,7 @@ describe('Store', () => {
         });
 
         beforeEach(() => {
-          Store.state.currentConnection = currentConnection;
+          Store.state.connectionModel = connectionModel;
           Store.state.fetchedConnections = new ConnectionCollection();
           Store.state.fetchedConnections.add(favoriteConnection);
           Store.state.connections = { [favorite._id]: favorite };
@@ -690,20 +690,20 @@ describe('Store', () => {
         it('sets the current connection in the store', (done) => {
           const unsubscribe = Store.listen((state) => {
             unsubscribe();
-            expect(state.currentConnection).to.exist;
-            expect(state.currentConnection._id).to.equal(
+            expect(state.connectionModel).to.exist;
+            expect(state.connectionModel._id).to.equal(
               favoriteConnection._id
             );
-            expect(state.currentConnection.color).to.equal(
+            expect(state.connectionModel.color).to.equal(
               favoriteConnection.color
             );
-            expect(state.currentConnection.name).to.equal(
+            expect(state.connectionModel.name).to.equal(
               favoriteConnection.name
             );
-            expect(state.currentConnection.port).to.equal(
+            expect(state.connectionModel.port).to.equal(
               favoriteConnection.port
             );
-            expect(state.currentConnection.isFavorite).to.equal(true);
+            expect(state.connectionModel.isFavorite).to.equal(true);
             expect(state.isValid).to.equal(true);
             expect(state.isConnected).to.equal(false);
             expect(state.errorMessage).to.equal(null);
@@ -717,7 +717,7 @@ describe('Store', () => {
       });
 
       context('when a recent is being selected', () => {
-        const currentConnection = new Connection();
+        const connectionModel = new Connection();
         const recentConnection = new Connection({
           hostname: 'localhost',
           port: '11111',
@@ -729,7 +729,7 @@ describe('Store', () => {
         });
 
         beforeEach(() => {
-          Store.state.currentConnection = currentConnection;
+          Store.state.connectionModel = connectionModel;
           Store.state.fetchedConnections = new ConnectionCollection();
           Store.state.fetchedConnections.add(recentConnection);
           Store.state.connections = { [favorite._id]: favorite };
@@ -738,14 +738,14 @@ describe('Store', () => {
         it('sets the current connection in the store', (done) => {
           const unsubscribe = Store.listen((state) => {
             unsubscribe();
-            expect(state.currentConnection).to.exist;
-            expect(state.currentConnection._id).to.equal(recentConnection._id);
-            expect(state.currentConnection.color).to.equal(undefined);
-            expect(state.currentConnection.name).to.equal('Local');
-            expect(state.currentConnection.port).to.equal(
+            expect(state.connectionModel).to.exist;
+            expect(state.connectionModel._id).to.equal(recentConnection._id);
+            expect(state.connectionModel.color).to.equal(undefined);
+            expect(state.connectionModel.name).to.equal('Local');
+            expect(state.connectionModel.port).to.equal(
               recentConnection.port
             );
-            expect(state.currentConnection.isFavorite).to.equal(false);
+            expect(state.connectionModel.isFavorite).to.equal(false);
             expect(state.isValid).to.equal(true);
             expect(state.isConnected).to.equal(false);
             expect(state.errorMessage).to.equal(null);
@@ -785,7 +785,7 @@ describe('Store', () => {
         };
 
         beforeEach(() => {
-          Store.state.currentConnection = currentFavConnection;
+          Store.state.connectionModel = currentFavConnection;
           Store.state.fetchedConnections = new ConnectionCollection();
           Store.state.fetchedConnections.add(currentFavConnection);
           Store.state.fetchedConnections.add(newFavConnection);
@@ -795,18 +795,18 @@ describe('Store', () => {
         it('sets the current connection in the store', (done) => {
           const unsubscribe = Store.listen((state) => {
             unsubscribe();
-            expect(state.currentConnection).to.exist;
-            expect(state.currentConnection._id).to.equal(newFavConnection._id);
-            expect(state.currentConnection.color).to.equal(
+            expect(state.connectionModel).to.exist;
+            expect(state.connectionModel._id).to.equal(newFavConnection._id);
+            expect(state.connectionModel.color).to.equal(
               newFavConnection.color
             );
-            expect(state.currentConnection.name).to.equal(
+            expect(state.connectionModel.name).to.equal(
               newFavConnection.name
             );
-            expect(state.currentConnection.port).to.equal(
+            expect(state.connectionModel.port).to.equal(
               newFavConnection.port
             );
-            expect(state.currentConnection.isFavorite).to.equal(true);
+            expect(state.connectionModel.isFavorite).to.equal(true);
             expect(state.isValid).to.equal(true);
             expect(state.isConnected).to.equal(false);
             expect(state.errorMessage).to.equal(null);
@@ -840,7 +840,7 @@ describe('Store', () => {
         };
 
         beforeEach(() => {
-          Store.state.currentConnection = currentFavConnection;
+          Store.state.connectionModel = currentFavConnection;
           Store.state.fetchedConnections = new ConnectionCollection();
           Store.state.fetchedConnections.add(currentFavConnection);
           Store.state.fetchedConnections.add(recent);
@@ -850,13 +850,13 @@ describe('Store', () => {
         it('sets the current connection in the store', (done) => {
           const unsubscribe = Store.listen((state) => {
             unsubscribe();
-            expect(state.currentConnection).to.exist;
-            expect(state.currentConnection._id).to.equal(recent._id);
-            expect(state.currentConnection.color).to.equal(undefined);
-            expect(state.currentConnection.name).to.equal('Local');
-            expect(state.currentConnection.hostname).to.equal(recent.hostname);
-            expect(state.currentConnection.port).to.equal(recent.port);
-            expect(state.currentConnection.isFavorite).to.equal(false);
+            expect(state.connectionModel).to.exist;
+            expect(state.connectionModel._id).to.equal(recent._id);
+            expect(state.connectionModel.color).to.equal(undefined);
+            expect(state.connectionModel.name).to.equal('Local');
+            expect(state.connectionModel.hostname).to.equal(recent.hostname);
+            expect(state.connectionModel.port).to.equal(recent.port);
+            expect(state.connectionModel.isFavorite).to.equal(false);
             expect(state.isValid).to.equal(true);
             expect(state.isConnected).to.equal(false);
             expect(state.errorMessage).to.equal(null);
@@ -895,7 +895,7 @@ describe('Store', () => {
         };
 
         beforeEach(() => {
-          Store.state.currentConnection = currentRecent;
+          Store.state.connectionModel = currentRecent;
           Store.state.fetchedConnections = new ConnectionCollection();
           Store.state.fetchedConnections.add(currentRecent);
           Store.state.fetchedConnections.add(newFavConnection);
@@ -905,18 +905,18 @@ describe('Store', () => {
         it('sets the current connection in the store', (done) => {
           const unsubscribe = Store.listen((state) => {
             unsubscribe();
-            expect(state.currentConnection).to.exist;
-            expect(state.currentConnection._id).to.equal(newFavConnection._id);
-            expect(state.currentConnection.color).to.equal(
+            expect(state.connectionModel).to.exist;
+            expect(state.connectionModel._id).to.equal(newFavConnection._id);
+            expect(state.connectionModel.color).to.equal(
               newFavConnection.color
             );
-            expect(state.currentConnection.name).to.equal(
+            expect(state.connectionModel.name).to.equal(
               newFavConnection.name
             );
-            expect(state.currentConnection.port).to.equal(
+            expect(state.connectionModel.port).to.equal(
               newFavConnection.port
             );
-            expect(state.currentConnection.isFavorite).to.equal(true);
+            expect(state.connectionModel.isFavorite).to.equal(true);
             expect(state.isValid).to.equal(true);
             expect(state.isConnected).to.equal(false);
             expect(state.errorMessage).to.equal(null);
@@ -952,7 +952,7 @@ describe('Store', () => {
         };
 
         beforeEach(() => {
-          Store.state.currentConnection = currentRecent;
+          Store.state.connectionModel = currentRecent;
           Store.state.fetchedConnections = new ConnectionCollection();
           Store.state.fetchedConnections.add(currentRecent);
           Store.state.fetchedConnections.add(newRecent);
@@ -962,15 +962,15 @@ describe('Store', () => {
         it('sets the current connection in the store', (done) => {
           const unsubscribe = Store.listen((state) => {
             unsubscribe();
-            expect(state.currentConnection).to.exist;
-            expect(state.currentConnection._id).to.equal(newRecent._id);
-            expect(state.currentConnection.color).to.equal(undefined);
-            expect(state.currentConnection.name).to.equal('Local');
-            expect(state.currentConnection.hostname).to.equal(
+            expect(state.connectionModel).to.exist;
+            expect(state.connectionModel._id).to.equal(newRecent._id);
+            expect(state.connectionModel.color).to.equal(undefined);
+            expect(state.connectionModel.name).to.equal('Local');
+            expect(state.connectionModel.hostname).to.equal(
               newRecent.hostname
             );
-            expect(state.currentConnection.port).to.equal(newRecent.port);
-            expect(state.currentConnection.isFavorite).to.equal(false);
+            expect(state.connectionModel.port).to.equal(newRecent.port);
+            expect(state.connectionModel.isFavorite).to.equal(false);
             expect(state.isValid).to.equal(true);
             expect(state.isConnected).to.equal(false);
             expect(state.errorMessage).to.equal(null);
@@ -1036,7 +1036,7 @@ describe('Store', () => {
                 showIndeterminateProgressBar: () => {},
                 done: () => {}
               };
-              Store.state.currentConnection = connection;
+              Store.state.connectionModel = connection;
               Store.state.isURIEditable = true;
             });
 
@@ -1055,8 +1055,8 @@ describe('Store', () => {
                 'mongodb://server.example.com:27017/?readPreference=primary&ssl=false';
               const unsubscribe = Store.listen((state) => {
                 unsubscribe();
-                expect(state.currentConnection).to.exist;
-                expect(state.currentConnection.driverUrl).to.equal(driverUrl);
+                expect(state.connectionModel).to.exist;
+                expect(state.connectionModel.driverUrl).to.equal(driverUrl);
                 done();
               });
 
@@ -1066,8 +1066,8 @@ describe('Store', () => {
             it('keeps the current connection id', (done) => {
               const unsubscribe = Store.listen((state) => {
                 unsubscribe();
-                expect(state.currentConnection).to.exist;
-                expect(state.currentConnection._id).to.equal(connection._id);
+                expect(state.connectionModel).to.exist;
+                expect(state.connectionModel._id).to.equal(connection._id);
                 done();
               });
 
@@ -1095,15 +1095,15 @@ describe('Store', () => {
                 showIndeterminateProgressBar: () => {},
                 done: () => {}
               };
-              Store.state.currentConnection = connection;
+              Store.state.connectionModel = connection;
               Store.state.isURIEditable = false;
             });
 
             it('sets the real password for the current connection', (done) => {
               const unsubscribe = Store.listen((state) => {
                 unsubscribe();
-                expect(state.currentConnection).to.exist;
-                expect(state.currentConnection.mongodbPassword).to.equal(
+                expect(state.connectionModel).to.exist;
+                expect(state.connectionModel.mongodbPassword).to.equal(
                   'password'
                 );
                 done();
@@ -1140,8 +1140,8 @@ describe('Store', () => {
               'mongodb://localhost:27017/?readPreference=primary&ssl=false';
             const unsubscribe = Store.listen((state) => {
               unsubscribe();
-              expect(state.currentConnection).to.exist;
-              expect(state.currentConnection.driverUrl).to.equal(driverUrl);
+              expect(state.connectionModel).to.exist;
+              expect(state.connectionModel.driverUrl).to.equal(driverUrl);
               expect(state.isValid).to.equal(false);
               expect(state.errorMessage).to.equal(null);
               done();
@@ -1177,8 +1177,8 @@ describe('Store', () => {
               'mongodb://localhost:27017/?readPreference=primary&ssl=false';
             const unsubscribe = Store.listen((state) => {
               unsubscribe();
-              expect(state.currentConnection).to.exist;
-              expect(state.currentConnection.driverUrl).to.equal(driverUrl);
+              expect(state.connectionModel).to.exist;
+              expect(state.connectionModel.driverUrl).to.equal(driverUrl);
               expect(state.isValid).to.equal(true);
               expect(state.errorMessage).to.equal(null);
               expect(state.syntaxErrorMessage).to.equal(null);
@@ -1202,7 +1202,7 @@ describe('Store', () => {
               showIndeterminateProgressBar: () => {},
               done: () => {}
             };
-            Store.state.currentConnection = connection;
+            Store.state.connectionModel = connection;
           });
 
           it('sets the connectionString viewType', (done) => {
@@ -1230,8 +1230,8 @@ describe('Store', () => {
           it('keeps the current connection id', (done) => {
             const unsubscribe = Store.listen((state) => {
               unsubscribe();
-              expect(state.currentConnection).to.exist;
-              expect(state.currentConnection._id).to.equal(connection._id);
+              expect(state.connectionModel).to.exist;
+              expect(state.connectionModel._id).to.equal(connection._id);
               done();
             });
 
@@ -1245,7 +1245,7 @@ describe('Store', () => {
               Store.state.isValid = true;
               Store.state.viewType = 'connectionForm';
               Store.state.customUrl = 'fake';
-              Store.state.currentConnection.hostname = 'test';
+              Store.state.connectionModel.hostname = 'test';
               Store.state.isHostChanged = true;
               Store.StatusActions = {
                 showIndeterminateProgressBar: () => {},
@@ -1324,8 +1324,8 @@ describe('Store', () => {
     it('updates the name on the current connection model', (done) => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.name).to.equal('myconnection');
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.name).to.equal('myconnection');
         done();
       });
 
@@ -1335,7 +1335,7 @@ describe('Store', () => {
 
   describe('#onCreateFavoriteClicked', () => {
     beforeEach(() => {
-      Store.state.currentConnection = new Connection({
+      Store.state.connectionModel = new Connection({
         isFavorite: false,
         hostname: 'localhost',
         port: 27011
@@ -1349,10 +1349,10 @@ describe('Store', () => {
       const unsubscribe = Store.listen((state) => {
         unsubscribe();
 
-        const currentId = state.currentConnection._id;
+        const currentId = state.connectionModel._id;
 
-        expect(state.currentConnection).to.exist;
-        expect(state.currentConnection.isFavorite).to.equal(true);
+        expect(state.connectionModel).to.exist;
+        expect(state.connectionModel.isFavorite).to.equal(true);
         expect(state.connections[currentId]._id).to.equal(currentId);
         done();
       });
@@ -1428,14 +1428,14 @@ describe('Store', () => {
         Store.state.fetchedConnections = new ConnectionCollection();
         Store.state.fetchedConnections.add(connection);
         Store.state.connections = { ...connections };
-        Store.state.currentConnection = connection;
+        Store.state.connectionModel = connection;
       });
 
       it('selects a copy as current connection with new name and color', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
           expect(state.connections).to.exist;
-          expect(state.currentConnection).to.exist;
+          expect(state.connectionModel).to.exist;
 
           const copyId = Object.keys(state.connections).find(
             (key) => !Object.keys(connections).includes(key)
@@ -1449,7 +1449,7 @@ describe('Store', () => {
           expect(state.connections[copyId].isFavorite).to.equal(true);
           expect(state.connections[copyId]._id).to.not.equal(connection._id);
           expect(state.connections[copyId]._id).to.equal(
-            state.currentConnection._id
+            state.connectionModel._id
           );
           done();
         });
@@ -1465,7 +1465,7 @@ describe('Store', () => {
         name: 'ConnectionToCopy',
         color: '#3b8196'
       });
-      const currentConnection = new Connection({
+      const connectionModel = new Connection({
         hostname: 'localhost',
         port: 18017,
         name: 'CurrentConnection',
@@ -1476,7 +1476,7 @@ describe('Store', () => {
           props: true,
           derived: true
         }),
-        [currentConnection._id]: currentConnection.getAttributes({
+        [connectionModel._id]: connectionModel.getAttributes({
           props: true,
           derived: true
         })
@@ -1485,16 +1485,16 @@ describe('Store', () => {
       beforeEach(() => {
         Store.state.fetchedConnections = new ConnectionCollection();
         Store.state.fetchedConnections.add(connectionToCopy);
-        Store.state.fetchedConnections.add(currentConnection);
+        Store.state.fetchedConnections.add(connectionModel);
         Store.state.connections = { ...connections };
-        Store.state.currentConnection = currentConnection;
+        Store.state.connectionModel = connectionModel;
       });
 
       it('selects a copy as current connection with new name and color', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
           expect(state.connections).to.exist;
-          expect(state.currentConnection).to.exist;
+          expect(state.connectionModel).to.exist;
 
           const copyId = Object.keys(state.connections).find(
             (key) => !Object.keys(connections).includes(key)
@@ -1505,7 +1505,7 @@ describe('Store', () => {
             `${connectionToCopy.name} (copy)`
           );
           expect(state.connections[copyId].name).to.not.equal(
-            `${currentConnection.name} (copy)`
+            `${connectionModel.name} (copy)`
           );
           expect(state.connections[copyId].color).to.equal(undefined);
           expect(state.connections[copyId].isFavorite).to.equal(true);
@@ -1513,10 +1513,10 @@ describe('Store', () => {
             connectionToCopy._id
           );
           expect(state.connections[copyId]._id).to.not.equal(
-            currentConnection._id
+            connectionModel._id
           );
           expect(state.connections[copyId]._id).to.equal(
-            state.currentConnection._id
+            state.connectionModel._id
           );
           done();
         });
@@ -1545,7 +1545,7 @@ describe('Store', () => {
             Store.state.fetchedConnections = new ConnectionCollection();
             Store.state.fetchedConnections.add(favorite);
             Store.state.connections = { ...connections };
-            Store.state.currentConnection = favorite.set({
+            Store.state.connectionModel = favorite.set({
               hostname: 'server.newexample.com'
             });
             Store.state.isURIEditable = true;
@@ -1555,12 +1555,12 @@ describe('Store', () => {
           it('discards changes and shows the password', (done) => {
             const unsubscribe = Store.listen((state) => {
               unsubscribe();
-              expect(state.currentConnection).to.exist;
+              expect(state.connectionModel).to.exist;
 
               const driverUrl =
                 'mongodb://favorite.example.com:27017/?readPreference=primary&ssl=false';
 
-              expect(state.currentConnection.hostname).to.equal(
+              expect(state.connectionModel.hostname).to.equal(
                 favorite.hostname
               );
               expect(state.customUrl).to.equal(driverUrl);
@@ -1591,7 +1591,7 @@ describe('Store', () => {
             Store.state.fetchedConnections = new ConnectionCollection();
             Store.state.fetchedConnections.add(favorite);
             Store.state.connections = { ...connections };
-            Store.state.currentConnection = favorite.set({
+            Store.state.connectionModel = favorite.set({
               hostname: 'server.newexample.com'
             });
             Store.state.isURIEditable = false;
@@ -1602,7 +1602,7 @@ describe('Store', () => {
           it('discards changes and hides the password', (done) => {
             const unsubscribe = Store.listen((state) => {
               unsubscribe();
-              expect(state.currentConnection).to.exist;
+              expect(state.connectionModel).to.exist;
 
               const driverUrl =
                 'mongodb://user:*****@favorite.example.com:27001/?authSource=admin&readPreference=primary&ssl=false';
@@ -1629,7 +1629,7 @@ describe('Store', () => {
           Store.state.fetchedConnections = new ConnectionCollection();
           Store.state.fetchedConnections.add(recent);
           Store.state.connections = { ...connections };
-          Store.state.currentConnection = recent.set({
+          Store.state.connectionModel = recent.set({
             hostname: 'server.newexample.com'
           });
           Store.state.customUrl = 'mongodb://server.newexample.com/';
@@ -1638,12 +1638,12 @@ describe('Store', () => {
         it('discards changes', (done) => {
           const unsubscribe = Store.listen((state) => {
             unsubscribe();
-            expect(state.currentConnection).to.exist;
+            expect(state.connectionModel).to.exist;
 
             const driverUrl =
               'mongodb://server.example.com:27001/?readPreference=primary&ssl=false';
 
-            expect(state.currentConnection.hostname).to.equal(recent.hostname);
+            expect(state.connectionModel.hostname).to.equal(recent.hostname);
             expect(state.customUrl).to.equal(driverUrl);
             done();
           });
@@ -1671,14 +1671,14 @@ describe('Store', () => {
           Store.state.fetchedConnections = new ConnectionCollection();
           Store.state.fetchedConnections.add(favorite);
           Store.state.connections = { ...connections };
-          Store.state.currentConnection = favorite.set({ port: 27002 });
+          Store.state.connectionModel = favorite.set({ port: 27002 });
         });
 
         it('discards changes', (done) => {
           const unsubscribe = Store.listen((state) => {
             unsubscribe();
-            expect(state.currentConnection).to.exist;
-            expect(state.currentConnection.port).to.equal(favorite.port);
+            expect(state.connectionModel).to.exist;
+            expect(state.connectionModel.port).to.equal(favorite.port);
             done();
           });
 
@@ -1700,14 +1700,14 @@ describe('Store', () => {
           Store.state.fetchedConnections = new ConnectionCollection();
           Store.state.fetchedConnections.add(recent);
           Store.state.connections = { ...connections };
-          Store.state.currentConnection = recent.set({ port: 27002 });
+          Store.state.connectionModel = recent.set({ port: 27002 });
         });
 
         it('discards changes', (done) => {
           const unsubscribe = Store.listen((state) => {
             unsubscribe();
-            expect(state.currentConnection).to.exist;
-            expect(state.currentConnection.port).to.equal(recent.port);
+            expect(state.connectionModel).to.exist;
+            expect(state.connectionModel.port).to.equal(recent.port);
             done();
           });
 
@@ -1731,18 +1731,18 @@ describe('Store', () => {
         Store.state.fetchedConnections = new ConnectionCollection();
         Store.state.fetchedConnections.add(recent);
         Store.state.connections = { ...connections };
-        Store.state.currentConnection = recent;
+        Store.state.connectionModel = recent;
       });
 
       it('adds recent to favorites', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
           expect(state.connections).to.exist;
-          expect(state.currentConnection).to.exist;
+          expect(state.connectionModel).to.exist;
           expect(Object.keys(state.connections).length).to.equal(1);
           expect(state.isMessageVisible).to.equal(true);
-          expect(state.currentConnection.isFavorite).to.equal(true);
-          expect(state.currentConnection.name).to.equal('localhost:27001');
+          expect(state.connectionModel.isFavorite).to.equal(true);
+          expect(state.connectionModel.name).to.equal('localhost:27001');
           expect(state.savedMessage).to.equal('Saved to favorites');
           done();
         });
@@ -1752,7 +1752,7 @@ describe('Store', () => {
     });
 
     context('when it is not current connection', () => {
-      const currentConnection = new Connection({
+      const connectionModel = new Connection({
         hostname: 'localhost',
         port: '27001'
       });
@@ -1768,18 +1768,18 @@ describe('Store', () => {
         Store.state.fetchedConnections = new ConnectionCollection();
         Store.state.fetchedConnections.add(recent);
         Store.state.connections = { ...connections };
-        Store.state.currentConnection = currentConnection;
+        Store.state.connectionModel = connectionModel;
       });
 
       it('adds recent to favorites', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
           expect(state.connections).to.exist;
-          expect(state.currentConnection).to.exist;
+          expect(state.connectionModel).to.exist;
           expect(Object.keys(state.connections).length).to.equal(1);
           expect(state.isMessageVisible).to.equal(true);
-          expect(state.currentConnection.isFavorite).to.equal(true);
-          expect(state.currentConnection.name).to.equal('localhost:27002');
+          expect(state.connectionModel.isFavorite).to.equal(true);
+          expect(state.connectionModel.name).to.equal('localhost:27002');
           expect(state.savedMessage).to.equal('Saved to favorites');
           done();
         });
@@ -1804,7 +1804,7 @@ describe('Store', () => {
       Store.state.fetchedConnections = new ConnectionCollection();
       Store.state.fetchedConnections.add(connection);
       Store.state.connections = { ...connections };
-      Store.state.currentConnection = connection;
+      Store.state.connectionModel = connection;
       Store.state.isURIEditable = false;
       Store.state.viewType = 'connectionString';
       Store.state.customUrl = connection.driverUrl;
@@ -1813,7 +1813,7 @@ describe('Store', () => {
       Store.state.connections = { ...connections };
       Store.state.currentConnectionAttempt = null;
       Store.state.isConnected = false;
-      Store.state.currentConnection = connection;
+      Store.state.connectionModel = connection;
 
       Store.state.currentConnectionAttempt = null;
       Store.dataService = null;
@@ -1980,9 +1980,9 @@ describe('Store', () => {
       Store.state.fetchedConnections.add(favorite);
       Store.state.connections = { ...connections };
       Store.state.currentConnectionAttempt = null;
-      Store.state.currentConnection = favorite;
+      Store.state.connectionModel = favorite;
       Store._connect = (parsedConnection) => {
-        Store.state.currentConnection = parsedConnection;
+        Store.state.connectionModel = parsedConnection;
         Store.trigger(Store.state);
       };
     });
@@ -1994,7 +1994,7 @@ describe('Store', () => {
     it('uses a real password when builds a driverUrl', async() => {
       await Actions.onConnectClicked();
 
-      expect(Store.state.currentConnection.driverUrl).to.equal(
+      expect(Store.state.connectionModel.driverUrl).to.equal(
         'mongodb://user:password@server.example.com:27001/?authSource=admin&readPreference=primary&ssl=false'
       );
     });
@@ -2102,7 +2102,7 @@ describe('Store', () => {
         Store.state.fetchedConnections = new ConnectionCollection();
         Store.state.fetchedConnections.add(favorite);
         Store.state.connections = { ...connections };
-        Store.state.currentConnection = favorite.set({
+        Store.state.connectionModel = favorite.set({
           port: 27018,
           name: 'New name',
           color: '#5fc86e'
@@ -2113,13 +2113,13 @@ describe('Store', () => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
           expect(state.connections).to.exist;
-          expect(state.currentConnection).to.exist;
+          expect(state.connectionModel).to.exist;
           expect(Object.keys(state.connections).length).to.equal(1);
-          expect(state.currentConnection._id).to.equal(favorite._id);
-          expect(state.currentConnection.port).to.equal(27018);
-          expect(state.currentConnection.name).to.equal('New name');
-          expect(state.currentConnection.color).to.equal('#5fc86e');
-          expect(state.currentConnection.isFavorite).to.equal(true);
+          expect(state.connectionModel._id).to.equal(favorite._id);
+          expect(state.connectionModel.port).to.equal(27018);
+          expect(state.connectionModel.name).to.equal('New name');
+          expect(state.connectionModel.color).to.equal('#5fc86e');
+          expect(state.connectionModel.isFavorite).to.equal(true);
           expect(state.connections[favorite._id].port).to.equal(27018);
           expect(state.connections[favorite._id].name).to.equal('New name');
           expect(state.connections[favorite._id].color).to.equal('#5fc86e');
@@ -2155,22 +2155,22 @@ describe('Store', () => {
         Store.state.fetchedConnections = new ConnectionCollection();
         Store.state.fetchedConnections.add(favorite);
         Store.state.connections = { ...connections };
-        Store.state.currentConnection = favorite;
+        Store.state.connectionModel = favorite;
       });
 
       it('updates properties of the saved connection', (done) => {
         const unsubscribe = Store.listen((state) => {
           unsubscribe();
           expect(state.connections).to.exist;
-          expect(state.currentConnection).to.exist;
+          expect(state.connectionModel).to.exist;
           expect(Object.keys(state.connections).length).to.equal(1);
-          expect(state.currentConnection._id).to.equal(favorite._id);
-          expect(state.currentConnection.port).to.equal(27018);
-          expect(state.currentConnection.name).to.equal(
+          expect(state.connectionModel._id).to.equal(favorite._id);
+          expect(state.connectionModel.port).to.equal(27018);
+          expect(state.connectionModel.name).to.equal(
             'It is a favorite connection'
           );
-          expect(state.currentConnection.color).to.equal('#3b8196');
-          expect(state.currentConnection.isFavorite).to.equal(true);
+          expect(state.connectionModel.color).to.equal('#3b8196');
+          expect(state.connectionModel.isFavorite).to.equal(true);
           expect(state.connections[favorite._id].port).to.equal(27018);
           expect(state.connections[favorite._id].isFavorite).to.equal(true);
           done();


### PR DESCRIPTION
This PR renames `currentConnection` to `connectionModel` in the store. 