### PR TITLE
chore: Debounce showing showing connecting modal

### DIFF
--- a/src/components/connect.less
+++ b/src/components/connect.less
@@ -649,6 +649,7 @@ label {
 
   .connecting-background-gradient {
     opacity: 0.9;
+    animation: opacityFadeIn 500ms ease-out;
   }
 }
 
@@ -660,11 +661,6 @@ label {
   100% {
     opacity: 1;
   }
-}
-
-.connecting-modal-container {
-  opacity: 1;
-  animation: opacityFadeIn 100ms ease-out;
 }
 
 .connecting-modal-content {

--- a/src/components/modal/connecting.jsx
+++ b/src/components/modal/connecting.jsx
@@ -8,6 +8,9 @@ import Actions from '../../actions';
 import Illustration from '../../assets/svg/connecting-illustration.svg';
 import styles from '../connect.less';
 
+// We delay showing the modal for this amount of time to avoid flashing.
+const showModalDelayMS = 250;
+
 /**
  * Modal shown when attempting to connect.
  */
@@ -17,9 +20,56 @@ class Connecting extends React.Component {
     currentConnectionAttempt: PropTypes.object
   };
 
+  state = {
+    showModal: false
+  };
+
+  componentDidUpdate = () => {
+    if (
+      this.props.currentConnectionAttempt
+      && !this.showModalDebounceTimeout
+      && !this.state.showModal
+    ) {
+      this.showModalDebounceTimeout = window.setTimeout(
+        () => {
+          if (this.props.currentConnectionAttempt) {
+            this.startShowingModal();
+          }
+          this.showModalDebounceTimeout = null;
+        },
+        showModalDelayMS
+      );
+    }
+
+    if (!this.props.currentConnectionAttempt && this.state.showModal) {
+      this.stopShowingModal();
+    }
+  }
+
+  componentWillUnmount = () => {
+    if (this.showModalDebounceTimeout) {
+      window.clearTimeout(this.showModalDebounceTimeout);
+      this.showModalDebounceTimeout = null;
+    }
+  }
+
   onCancelConnectionClicked = () => {
     Actions.onCancelConnectionAttemptClicked();
   };
+
+  startShowingModal = () => {
+    this.setState({
+      showModal: true
+    });
+  }
+
+  stopShowingModal = () => {
+    this.setState({
+      showModal: false
+    });
+  }
+
+  showModalDebounceTimeout = null;
 
   /**
    * @returns {React.Component} The background for the connecting modal.
@@ -89,9 +139,7 @@ class Connecting extends React.Component {
       <React.Fragment>
         {!!this.props.currentConnectionAttempt && this.renderConnectingBackground()}
         <Modal
-          animation={false}
-          containerClassName={styles['connecting-modal-container']}
-          show={!!this.props.currentConnectionAttempt}
+          show={this.state.showModal && !!this.props.currentConnectionAttempt}
           backdropClassName={styles['connecting-modal-backdrop']}
         >
           <Modal.Body>

--- a/src/components/modal/connecting.jsx
+++ b/src/components/modal/connecting.jsx
@@ -139,6 +139,7 @@ class Connecting extends React.Component {
       <React.Fragment>
         {!!this.props.currentConnectionAttempt && this.renderConnectingBackground()}
         <Modal
+          animation={false}
           show={this.state.showModal && !!this.props.currentConnectionAttempt}
           backdropClassName={styles['connecting-modal-backdrop']}
         >

--- a/src/components/modal/connecting.spec.js
+++ b/src/components/modal/connecting.spec.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import Connecting from './connecting';
+
+const delay = (amt) => new Promise((resolve) => setTimeout(resolve, amt));
+
+describe('Connecting [Component]', () => {
+  let component;
+
+  before(() => {
+    window.requestAnimationFrame = () => {};
+  });
+
+  beforeEach(() => {
+    component = mount(<Connecting
+      connectingStatusText="connecting..."
+      currentConnectionAttempt={undefined}
+    />);
+  });
+
+  afterEach(() => {
+    component = null;
+  });
+
+  it('has show modal false by default', () => {
+    expect(component.state('showModal')).to.equal(false);
+  });
+
+  it('sets show modal true after 250ms', async() => {
+    component.setProps({
+      currentConnectionAttempt: { truthyObject: true }
+    });
+
+    await delay(5);
+
+    expect(component.state('showModal')).to.equal(false);
+
+    await delay(300);
+
+    expect(component.state('showModal')).to.equal(true);
+  });
+
+  it('does not set show modal true if currentConnectionAttempt is set to false', async() => {
+    component.setProps({
+      currentConnectionAttempt: { truthyObject: true }
+    });
+
+    await delay(5);
+
+    expect(component.state('showModal')).to.equal(false);
+
+    component.setProps({
+      currentConnectionAttempt: undefined
+    });
+
+    await delay(300);
+
+    expect(component.state('showModal')).to.equal(false);
+  });
+});

--- a/src/modules/connection-attempt.spec.js
+++ b/src/modules/connection-attempt.spec.js
@@ -17,10 +17,9 @@ describe('connection-attempt', () => {
     });
 
     it('returns null if is cancelled', async() => {
-      let rejectOnConnect;
       const dataService = {
-        connect: () => new Promise((_, _reject) => {
-          rejectOnConnect = _reject;
+        connect: () => new Promise((resolve) => {
+          setTimeout(() => resolve(), 100);
         })
       };
 
@@ -30,7 +29,6 @@ describe('connection-attempt', () => {
         dataService
       );
 
-      rejectOnConnect(new Error('should have been cancelled'));
       connectionAttempt.cancelConnectionAttempt();
 
       expect(await connectPromise).to.equal(null);


### PR DESCRIPTION
This PR makes it so the connecting modal delays showing for 250ms. This is so that localhost and really fast connections don't have the modal flash quickly by.
While it is not shown the screen is still covered by the background gradient, which transitions to being more visible overtime.


https://user-images.githubusercontent.com/1791149/107634179-695cfe00-6c69-11eb-8559-15b2516deadd.mp4

