### PR TITLE
fix: ensure styles are namespaced

### DIFF
--- a/src/components/connect.less
+++ b/src/components/connect.less
@@ -10,27 +10,22 @@
   flex: 1;
 }
 
-.panel {
-  border: 1px solid transparent;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
-}
-
-form {
-  display: block;
-  margin-top: 0em;
-  background-color: white;
-  box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.075);
-  padding: 15px 0;
-}
-
-label {
-  display: inline-block;
-  max-width: 100%;
-  margin-bottom: 5px;
-  font-weight: bold;
-}
-
 .connect {
+  form {
+    display: block;
+    margin-top: 0em;
+    background-color: white;
+    box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.075);
+    padding: 15px 0;
+  }
+
+  label {
+    display: inline-block;
+    max-width: 100%;
+    margin-bottom: 5px;
+    font-weight: bold;
+  }
+
   &-atlas {
     background: @compass-sidebar-atlas-background-color;
     display: flex;


### PR DESCRIPTION
Some of the styles were polluting compass' global namespace and changing the look of unexpected things. This PR removes an unused style definition and moves the global ones to be in the connect. We could definitely clean up the styles more in general here, but we can address another time.

Before:
<img width="447" alt="Screen Shot 2021-02-16 at 12 26 47 PM" src="https://user-images.githubusercontent.com/1791149/108057777-5d9b7e00-7053-11eb-9320-da7dc3456006.png">


After:
<img width="459" alt="Screen Shot 2021-02-16 at 12 33 03 PM" src="https://user-images.githubusercontent.com/1791149/108057788-60966e80-7053-11eb-89d5-bb23daf2c164.png">
