### PR TITLE
chore: Sort favorites by name alphabetic, sort recents by most recently at the top

### DIFF
--- a/src/components/sidebar/favorites.jsx
+++ b/src/components/sidebar/favorites.jsx
@@ -110,7 +110,8 @@ class Favorites extends React.Component {
   renderFavorites() {
     const favorites = Object.keys(this.props.connections)
       .map(key => this.props.connections[key])
-      .filter(connection => connection.isFavorite);
+      .filter(connection => connection.isFavorite)
+      .sort((a, b) => b.lastUsed - a.lastUsed);
 
     return map(favorites, (favorite, i) => {
       const title = `${favorite.hostname}:${favorite.port}`;

--- a/src/components/sidebar/favorites.jsx
+++ b/src/components/sidebar/favorites.jsx
@@ -111,7 +111,12 @@ class Favorites extends React.Component {
     const favorites = Object.keys(this.props.connections)
       .map(key => this.props.connections[key])
       .filter(connection => connection.isFavorite)
-      .sort((a, b) => b.lastUsed - a.lastUsed);
+      .sort((a, b) => {
+        return (`${b.name}`.toLowerCase() < `${a.name}`.toLowerCase()
+          ? 1
+          : -1
+        );
+      });
 
     return map(favorites, (favorite, i) => {
       const title = `${favorite.hostname}:${favorite.port}`;

--- a/src/components/sidebar/favorites.spec.js
+++ b/src/components/sidebar/favorites.spec.js
@@ -21,10 +21,6 @@ describe('Favorites [Component]', () => {
       );
     });
 
-    afterEach(() => {
-      component = null;
-    });
-
     it('renders the wrapper div', () => {
       const style = '.connect-sidebar-connections-favorites';
 
@@ -78,14 +74,41 @@ describe('Favorites [Component]', () => {
       );
     });
 
-    afterEach(() => {
-      component = null;
-    });
-
     it('sets a default color for the right border ', () => {
       const favorite = component.find(`.${styles['connect-sidebar-list-item']}`);
 
       expect(favorite.prop('style')).to.deep.equal({ borderRight: '5px solid #2c5f4a' });
+    });
+  });
+
+  context('multiple favorites', () => {
+    const favorites = {
+      '674f5a6b-f4ba-4e5c-a5c8-f557fdc06f40': {
+        name: 'second',
+        isFavorite: true,
+        color: '#2c5f4a'
+      },
+      '674f5a6b-f4ba-4e5c-a5c8-f557fdc06f41': {
+        name: 'third',
+        isFavorite: true,
+        color: '#2c5f4a'
+      },
+      '674f5a6b-f4ba-4e5c-a5c8-f557fdc06f42': {
+        name: 'first',
+        isFavorite: true,
+        color: '#2c5f4a'
+      }
+    };
+
+    it('renders them in alphabetical order', () => {
+      const component = mount(
+        <Favorites connectionModel={{}} connections={favorites} />
+      );
+
+      const style = `.${styles['connect-sidebar-list-item-name']}`;
+
+      expect(component.find(style).at(0).text()).to.be.equal('first');
+      expect(component.find(style).at(2).text()).to.be.equal('third');
     });
   });
 });

--- a/src/components/sidebar/recents.jsx
+++ b/src/components/sidebar/recents.jsx
@@ -141,7 +141,13 @@ class Recents extends React.Component {
     const recents = Object.keys(this.props.connections)
       .map(key => this.props.connections[key])
       .filter(connection => !connection.isFavorite)
-      .sort((a, b) => b.lastUsed - a.lastUsed);
+      .sort((a, b) => {
+        // The `lastUsed` value hasn't always existed, so we assign
+        // them a date in 2016 for sorting if it isn't there.
+        const aLastUsed = a.lastUsed ? a.lastUsed : 1463658247465;
+        const bLastUsed = b.lastUsed ? b.lastUsed : 1463658247465;
+        return bLastUsed - aLastUsed;
+      });
 
     const clearAllDiv =
       recents.length > 0 ? (

--- a/src/components/sidebar/recents.jsx
+++ b/src/components/sidebar/recents.jsx
@@ -58,23 +58,6 @@ class Recents extends React.Component {
   }
 
   /**
-   * Gets a proper class name for active and not active recent connections.
-   *
-   * @param {Object} recent - A recent connection.
-   *
-   * @returns {String} - A class name
-   */
-  getClassName(recent) {
-    const classnamesProps = [styles['connect-sidebar-list-item']];
-
-    if (this.props.connectionModel._id === recent._id) {
-      classnamesProps.push(styles['connect-sidebar-list-item-is-active']);
-    }
-
-    return classnames(...classnamesProps);
-  }
-
-  /**
    * Formats lastUsed.
    *
    * @param {Object} model - A connection model.
@@ -106,23 +89,23 @@ class Recents extends React.Component {
 
       return (
         <li
-          className={this.getClassName(recent)}
+          className={classnames(styles['connect-sidebar-list-item'], {
+            [styles['connect-sidebar-list-item-is-active']]: this.props.connectionModel._id === recent._id
+          })}
           key={i}
           title={title}
           onClick={this.onRecentClicked.bind(this, recent)}
         >
           <div
-            className={classnames(styles['connect-sidebar-list-item-details'])}
+            className={styles['connect-sidebar-list-item-details']}
           >
             <div
-              className={classnames(
-                styles['connect-sidebar-list-item-last-used']
-              )}
+              className={styles['connect-sidebar-list-item-last-used']}
             >
               {this.formatLastUsed(recent)}
             </div>
             <div
-              className={classnames(styles['connect-sidebar-list-item-name'])}
+              className={styles['connect-sidebar-list-item-name']}
             >
               {title}
             </div>
@@ -131,7 +114,7 @@ class Recents extends React.Component {
             bsSize="xsmall"
             bsStyle="link"
             title="&hellip;"
-            className={classnames(styles['connect-sidebar-list-item-actions'])}
+            className={styles['connect-sidebar-list-item-actions']}
             noCaret
             pullRight
             id="recent-actions"
@@ -157,15 +140,14 @@ class Recents extends React.Component {
   render() {
     const recents = Object.keys(this.props.connections)
       .map(key => this.props.connections[key])
-      .filter(connection => !connection.isFavorite);
-    const clearClassName = classnames(
-      styles['connect-sidebar-header-recent-clear']
-    );
+      .filter(connection => !connection.isFavorite)
+      .sort((a, b) => b.lastUsed - a.lastUsed);
+
     const clearAllDiv =
       recents.length > 0 ? (
         <div
           onClick={this.onClearConnectionsClicked}
-          className={clearClassName}
+          className={styles['connect-sidebar-header-recent-clear']}
         >
           Clear all
         </div>
@@ -175,8 +157,8 @@ class Recents extends React.Component {
 
     return (
       <div className="connect-sidebar-connections-recents">
-        <div className={classnames(styles['connect-sidebar-header'])}>
-          <div className={classnames(styles['connect-sidebar-header-recent'])}>
+        <div className={styles['connect-sidebar-header']}>
+          <div className={styles['connect-sidebar-header-recent']}>
             <div>
               <i className="fa fa-fw fa-history" />
               <span>Recents</span>
@@ -184,7 +166,7 @@ class Recents extends React.Component {
             {clearAllDiv}
           </div>
         </div>
-        <ul className={classnames(styles['connect-sidebar-list'])}>
+        <ul className={styles['connect-sidebar-list']}>
           {this.renderRecents(recents)}
         </ul>
       </div>

--- a/src/components/sidebar/recents.spec.js
+++ b/src/components/sidebar/recents.spec.js
@@ -6,55 +6,106 @@ import Recents from './recents';
 import styles from './sidebar.less';
 
 describe('Recents [Component]', () => {
-  const recents = {
-    '674f5a6b-f4ba-4e5c-a5c8-f557fdc06f40': {
-      hostname: 'dev',
-      port: 27000,
-      isRecent: true,
-      isFavorite: false
-    }
-  };
-  let component;
+  describe('when rendered', () => {
+    const recents = {
+      '674f5a6b-f4ba-4e5c-a5c8-f557fdc06f40': {
+        hostname: 'dev',
+        port: 27000,
+        isRecent: true,
+        isFavorite: false
+      }
+    };
+    let component;
 
-  beforeEach(() => {
-    component = mount(<Recents connectionModel={{}} connections={recents} />);
+    beforeEach(() => {
+      component = mount(<Recents connectionModel={{}} connections={recents} />);
+    });
+
+    afterEach(() => {
+      component = null;
+    });
+
+    it('renders the wrapper div', () => {
+      const style = '.connect-sidebar-connections-recents';
+
+      expect(component.find(style)).to.be.present();
+    });
+
+    it('renders the header', () => {
+      const style = `.${styles['connect-sidebar-header']}`;
+
+      expect(component.find(style)).to.be.present();
+    });
+
+    it('renders the recents icon', () => {
+      expect(component.find('i.fa-history')).to.be.present();
+    });
+
+    it('renders clear all connections text', () => {
+      const style = `.${styles['connect-sidebar-header-recent-clear']}`;
+
+      expect(component.find(style)).to.have.text('Clear all');
+    });
+
+    it('renders the recent name', () => {
+      const style = `.${styles['connect-sidebar-list-item-name']}`;
+
+      expect(component.find(style)).to.have.text('dev:27000');
+    });
+
+    it('renders the recent lastUsed ', () => {
+      const style = `.${styles['connect-sidebar-list-item-last-used']}`;
+
+      expect(component.find(style)).to.have.text('Never');
+    });
   });
 
-  afterEach(() => {
-    component = null;
-  });
+  describe('when rendered with multiple recents', () => {
+    const now = Date.now();
 
-  it('renders the wrapper div', () => {
-    const style = '.connect-sidebar-connections-recents';
+    const recents = {
+      '674f5a6b-f4ba-4e5c-a5c8-f557fdc06f40': {
+        hostname: 'dev1',
+        port: 27000,
+        isRecent: true,
+        isFavorite: false,
+        lastUsed: (now + 1)
+      },
+      '674f5a6b-f4ba-4e5c-a5c8-f557fdc06f41': {
+        hostname: 'dev2',
+        port: 27000,
+        isRecent: true,
+        isFavorite: false,
+        lastUsed: undefined // This field didn't used to exist.
+      },
+      '674f5a6b-f4ba-4e5c-a5c8-f557fdc06f42': {
+        hostname: 'dev3',
+        port: 27000,
+        isRecent: true,
+        isFavorite: false,
+        lastUsed: (now + 2)
+      },
+      '674f5a6b-f4ba-4e5c-a5c8-f557fdc06f43': {
+        hostname: 'dev4',
+        port: 27000,
+        isRecent: true,
+        isFavorite: false,
+        lastUsed: (now - 1)
+      }
+    };
 
-    expect(component.find(style)).to.be.present();
-  });
+    it('renders them in descending order from lastUsed date', () => {
+      const component = mount(<Recents
+        connectionModel={{}}
+        connections={recents}
+      />);
 
-  it('renders the header', () => {
-    const style = `.${styles['connect-sidebar-header']}`;
+      const style = `.${styles['connect-sidebar-list-item-name']}`;
 
-    expect(component.find(style)).to.be.present();
-  });
-
-  it('renders the recents icon', () => {
-    expect(component.find('i.fa-history')).to.be.present();
-  });
-
-  it('renders clear all connections text', () => {
-    const style = `.${styles['connect-sidebar-header-recent-clear']}`;
-
-    expect(component.find(style)).to.have.text('Clear all');
-  });
-
-  it('renders the recent name', () => {
-    const style = `.${styles['connect-sidebar-list-item-name']}`;
-
-    expect(component.find(style)).to.have.text('dev:27000');
-  });
-
-  it('renders the recent lastUsed ', () => {
-    const style = `.${styles['connect-sidebar-list-item-last-used']}`;
-
-    expect(component.find(style)).to.have.text('Never');
+      expect(component.find(style).at(0).text()).to.equal('dev3:27000');
+      expect(component.find(style).at(1).text()).to.equal('dev1:27000');
+      expect(component.find(style).at(2).text()).to.equal('dev4:27000');
+      expect(component.find(style).at(3).text()).to.equal('dev2:27000');
+    });
   });
 });


### PR DESCRIPTION
This PR updates the sort order of connections sidebar. Favorites alphabetical, recents descending by last used.


<img width="274" alt="Screen Shot 2021-02-18 at 3 30 53 PM" src="https://user-images.githubusercontent.com/1791149/108371766-5e244800-71fe-11eb-8e74-7db44fc92aca.png">
<img width="272" alt="Screen Shot 2021-02-18 at 3 31 03 PM" src="https://user-images.githubusercontent.com/1791149/108371758-5c5a8480-71fe-11eb-96a0-b7206dee0fc3.png">