### PR TITLE
chore: use enzyme chai in karma tests, remove deprecated false positive tests

### DIFF
--- a/src/components/form/form-actions.jsx
+++ b/src/components/form/form-actions.jsx
@@ -1,7 +1,6 @@
 import Button from '@leafygreen-ui/button';
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 import Actions from '../../actions';
 import FormGroup from './form-group';
@@ -121,7 +120,7 @@ class FormActions extends React.Component {
    */
   renderUnsavedMessage() {
     return (
-      <div className={classnames(styles['unsaved-message-actions'])}>
+      <div className={styles['unsaved-message-actions']}>
         You have unsaved changes.
         <a id="discardChanges" onClick={this.onChangesDiscarded}>
           [discard]
@@ -251,7 +250,7 @@ class FormActions extends React.Component {
    */
   renderConnectButtons() {
     return (
-      <div className={classnames(styles.buttons)}>
+      <div className={styles.buttons}>
         {!this.props.currentConnectionAttempt && (
           this.props.isURIEditable
             ? this.renderHideURI()
@@ -298,7 +297,7 @@ class FormActions extends React.Component {
     if (hasMessage === true) {
       return (
         <div className={styles['connection-message-container']}>
-          <div className={classnames(colorStyle)}>
+          <div className={colorStyle}>
             <div className={styles['connection-message']}>{message}</div>
           </div>
         </div>

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -1,5 +1,13 @@
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
+const chai = require('chai');
+const chaiEnzyme = require('chai-enzyme');
+const sinonChai = require('sinon-chai');
+
+chai.should();
+chai.use(sinonChai);
+chai.use(chaiEnzyme());
+global.expect = chai.expect;
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/test/renderer/components/connect.spec.js
+++ b/test/renderer/components/connect.spec.js
@@ -44,7 +44,7 @@ describe('Connect [Component]', () => {
     });
 
     it('renders the container', () => {
-      expect(component.find(`.${styles.connect}`)).to.exist;
+      expect(component.find(`.${styles.connect}`)).to.be.present();
     });
 
     it('renders the header', () => {
@@ -52,35 +52,7 @@ describe('Connect [Component]', () => {
     });
 
     it('renders the form container', () => {
-      expect(component.find(`.${styles['form-container']}`)).to.exist;
-    });
-  });
-
-  context('when the app is connected', () => {
-    let component;
-
-    beforeEach(() => {
-      component = shallow(
-        <Connect
-          connectionModel={connection}
-          connections={connections}
-          isConnected
-          isValid />
-      );
-    });
-
-    afterEach(() => {
-      component = null;
-    });
-
-    before(() => {
-      global.hadronApp = hadronApp;
-      global.hadronApp.appRegistry = appRegistry;
-      global.hadronApp.appRegistry.registerRole('Application.Status', ROLE);
-    });
-
-    it('renders the success header', () => {
-      expect(component.find('.success')).to.exist;
+      expect(component.find(`.${styles['form-container']}`)).to.be.present();
     });
   });
 });

--- a/test/renderer/components/form-file-input.spec.js
+++ b/test/renderer/components/form-file-input.spec.js
@@ -20,7 +20,7 @@ describe('FormFileInput [Component]', () => {
     });
 
     it('renders the wrapper div', () => {
-      expect(component.find(`.${styles['form-item']}`)).to.exist;
+      expect(component.find(`.${styles['form-item']}`)).to.be.present();
     });
 
     it('renders the label', () => {
@@ -36,7 +36,7 @@ describe('FormFileInput [Component]', () => {
     });
 
     it('renders the file icon', () => {
-      expect(component.find('.fa-upload')).to.exist;
+      expect(component.find('.fa-upload')).to.be.present();
     });
   });
 });

--- a/test/renderer/components/ssh-tunnel-identity-file-validation.spec.js
+++ b/test/renderer/components/ssh-tunnel-identity-file-validation.spec.js
@@ -28,7 +28,7 @@ describe('SSHTunnelIdentityFile [Component]', () => {
       });
 
       it('renders the wrapper div', () => {
-        expect(component.find(`.${styles['form-group']}`)).to.exist;
+        expect(component.find(`.${styles['form-group']}`)).to.be.present();
       });
 
       it('renders the sshTunnelHostname input', () => {
@@ -93,12 +93,8 @@ describe('SSHTunnelIdentityFile [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
 
@@ -121,12 +117,8 @@ describe('SSHTunnelIdentityFile [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
 
@@ -149,12 +141,8 @@ describe('SSHTunnelIdentityFile [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
 
@@ -177,12 +165,8 @@ describe('SSHTunnelIdentityFile [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
     });

--- a/test/renderer/components/ssh-tunnel-password-validation.spec.js
+++ b/test/renderer/components/ssh-tunnel-password-validation.spec.js
@@ -27,7 +27,7 @@ describe('SSHTunnelPassword [Component]', () => {
       });
 
       it('renders the wrapper div', () => {
-        expect(component.find(`.${styles['form-group']}`)).to.exist;
+        expect(component.find(`.${styles['form-group']}`)).to.be.present();
       });
 
       it('renders the sshTunnelHostname input', () => {
@@ -74,12 +74,8 @@ describe('SSHTunnelPassword [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
 
@@ -101,12 +97,8 @@ describe('SSHTunnelPassword [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
 
@@ -128,12 +120,8 @@ describe('SSHTunnelPassword [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
 
@@ -155,12 +143,8 @@ describe('SSHTunnelPassword [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
     });

--- a/test/renderer/components/ssl-server-client-validation.spec.js
+++ b/test/renderer/components/ssl-server-client-validation.spec.js
@@ -27,7 +27,7 @@ describe('SSLServerClientValidation [Component]', () => {
       });
 
       it('renders the wrapper div', () => {
-        expect(component.find(`.${styles['form-group']}`)).to.exist;
+        expect(component.find(`.${styles['form-group']}`)).be.present();
       });
 
       it('renders the sslCA button', () => {
@@ -85,12 +85,8 @@ describe('SSLServerClientValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).be.present();
         });
       });
 
@@ -112,12 +108,8 @@ describe('SSLServerClientValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).be.present();
         });
       });
 
@@ -138,12 +130,8 @@ describe('SSLServerClientValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).be.present();
         });
       });
 
@@ -165,12 +153,8 @@ describe('SSLServerClientValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).be.present();
         });
       });
 
@@ -192,12 +176,8 @@ describe('SSLServerClientValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).be.present();
         });
       });
 
@@ -218,12 +198,8 @@ describe('SSLServerClientValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).be.present();
         });
       });
 
@@ -245,12 +221,8 @@ describe('SSLServerClientValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).be.present();
         });
       });
 
@@ -272,12 +244,8 @@ describe('SSLServerClientValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).be.present();
         });
       });
 
@@ -298,12 +266,8 @@ describe('SSLServerClientValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).be.present();
         });
       });
     });

--- a/test/renderer/components/ssl-server-validation.spec.js
+++ b/test/renderer/components/ssl-server-validation.spec.js
@@ -22,7 +22,7 @@ describe('SSLServerValidation [Component]', () => {
       });
 
       it('renders the wrapper div', () => {
-        expect(component.find(`.${styles['form-group']}`)).to.exist;
+        expect(component.find(`.${styles['form-group']}`)).to.be.present();
       });
 
       it('renders the file button', () => {
@@ -49,12 +49,8 @@ describe('SSLServerValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
 
@@ -72,12 +68,8 @@ describe('SSLServerValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
 
@@ -95,12 +87,8 @@ describe('SSLServerValidation [Component]', () => {
           component = null;
         });
 
-        it('renders the error icon', () => {
-          expect(component.find('.fa-exclamation-circle')).to.exist;
-        });
-
         it('renders the error class', () => {
-          expect(component.find(`.${styles['form-item-has-error']}`)).to.exist;
+          expect(component.find(`.${styles['form-item-has-error']}`)).to.be.present();
         });
       });
     });


### PR DESCRIPTION
Looks like the karma tests in this package weren't using chai-enzyme correctly, and at some point the tests started using an unrelated `.exists` function which would return some false positives. Looks like it was for old stuff so no real code changes.

This PR adds in chai enzyme for the karma tests and updates the .exists to `.present()`.