### PR TITLE
fix: long text overflow on connecting screen

### DIFF
--- a/src/components/connect.less
+++ b/src/components/connect.less
@@ -669,6 +669,9 @@
   .connecting-modal-status {
     margin-top: 24px;
     font-weight: bold;
+    max-height: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .connecting-modal-animation {


### PR DESCRIPTION

*before*
<img width="681" alt="Screen Shot 2021-03-21 at 2 37 29 PM" src="https://user-images.githubusercontent.com/1791149/111908940-112ccf00-8a53-11eb-91cc-6593764bdffa.png">

*after*
<img width="591" alt="Screen Shot 2021-03-21 at 2 35 39 PM" src="https://user-images.githubusercontent.com/1791149/111908937-0d994800-8a53-11eb-829e-9761e0f26956.png">
